### PR TITLE
Add interval versions of `lgamma` and `tgamma`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define collection "rival")
-(define version "1.4")
+(define version "1.7")
 
 ;; Packaging information
 

--- a/main.rkt
+++ b/main.rkt
@@ -1052,6 +1052,8 @@
              (bf-equals? (ival-hi-val ival1) (ival-hi-val ival2)))))
 
   (define num-tests 2500)
+  (define num-slow-tests 100)
+  (define slow-tests (list ival-lgamma ival-tgamma))
 
   (define (test-entry n ival-fn fn args)
     (define is (for/list ([arg args]) (sample-interval arg)))
@@ -1163,5 +1165,5 @@
   (for ([entry (in-list composed-function-table)])
     (match-define (list ival-fn fn args _) entry)
     (test-case (~a (object-name ival-fn))
-       (for ([n (in-range num-tests)])
+       (for ([n (in-range (if (set-member? slow-tests ival-fn) num-slow-tests num-tests))])
          (test-entry ival-fn fn args)))))

--- a/main.rkt
+++ b/main.rkt
@@ -81,6 +81,8 @@
           [ival-atanh (-> ival? ival?)]
           [ival-erf (-> ival? ival?)]
           [ival-erfc (-> ival? ival?)]
+          [ival-lgamma (-> ival? ival?)]
+          [ival-tgamma (-> ival? ival?)]
           [ival-fmod (-> ival? ival? ival?)]
           [ival-remainder (-> ival? ival? ival?)]
           [ival-rint (-> ival? ival?)]
@@ -754,7 +756,7 @@
           #t
           (or xerr (and (bf=? xlo xhi) (bf=? xlo (bffloor xlo)))))]))
 
-(define (ival-gamma x)
+(define (ival-tgamma x)
   (define logy (ival-lgamma x))
   (define absy (ival-exp logy))
   (if (bfeven? (bffloor (ival-lo-val x)))
@@ -946,6 +948,8 @@
           (list ival-atan2 bfatan2    '(real real) 'real)
           (list ival-fmod  bffmod     '(real real) 'real)
           (list ival-remainder bfremainder '(real real) 'real)
+          (list ival-tgamma bfgamma   '(real) 'real)
+          (list ival-lgamma bflog-gamma '(real) 'real)
           (list ival-<     bflt?      '(real real) 'bool)
           (list ival-<=    bflte?     '(real real) 'bool)
           (list ival->     bfgt?      '(real real) 'bool)

--- a/main.rkt
+++ b/main.rkt
@@ -759,9 +759,21 @@
 (define (ival-tgamma x)
   (define logy (ival-lgamma x))
   (define absy (ival-exp logy))
-  (if (bfeven? (bffloor (ival-lo-val x)))
-      absy
-      (ival-neg absy)))
+  (define lo (ival-lo-val x))
+  (define hi (ival-hi-val x))
+  (cond
+   [(bfpositive? lo)
+    absy]
+   [(not (bf=? (bffloor lo) (bffloor hi)))
+    (ival (endpoint -inf.bf (ival-lo-fixed? x))
+          (endpoint +inf.bf (ival-hi-fixed? x))
+          #t (ival-err x))]
+   [(and (not (bfpositive? lo)) (bf=? lo hi) (bfinteger? lo))
+    (ival-illegal)]
+   [(bfeven? (bffloor lo))
+    absy]
+   [else
+    (ival-neg absy)]))
 
 (define* ival-erf (monotonic bferf))
 (define* ival-erfc (comonotonic bferfc))

--- a/main.rkt
+++ b/main.rkt
@@ -753,13 +753,13 @@
     ((convex bflog-gamma xmin ymin) x)]
    [(bf=? (bfadd 2.bf (bffloor xlo)) (bfceiling xhi))
     (ival-union
-     (ival-lgamma (ival (endpoint xlo xlo!) (endpoint (bfceiling xlo) (and xlo! xhi!)) err? err))
-     (ival-lgamma (ival (endpoint (bffloor xhi) (and xlo! xhi!)) (endpoint xhi xhi!) err? err)))]
+     (ival-lgamma (ival (endpoint xlo xlo!) (endpoint (bfceiling xlo) (and xlo! xhi!)) xerr? xerr))
+     (ival-lgamma (ival (endpoint (bffloor xhi) (and xlo! xhi!)) (endpoint xhi xhi!) xerr? xerr)))]
    [else
     (ival-union
-     (ival-lgamma (ival (endpoint xlo xlo!) (endpoint (bfceiling xlo) (and xlo! xhi!)) err? err))
+     (ival-lgamma (ival (endpoint xlo xlo!) (endpoint (bfceiling xlo) (and xlo! xhi!)) xerr? xerr))
      (ival-lgamma (ival (endpoint (bfceiling xlo) (and xlo! xhi!))
-                        (endpoint (bfadd 1.bf (bfceiling xlo)) (and xlo! xhi!)) err? err)))]))
+                        (endpoint (bfadd 1.bf (bfceiling xlo)) (and xlo! xhi!)) xerr? xerr)))]))
 
 (define (ival-tgamma x)
   (define logy (ival-lgamma x))

--- a/main.rkt
+++ b/main.rkt
@@ -769,7 +769,7 @@
           (endpoint +inf.bf (ival-hi-fixed? x))
           #t (ival-err x))]
    [(and (not (bfpositive? lo)) (bf=? lo hi) (bfinteger? lo))
-    (ival-illegal)]
+    ival-illegal]
    [(bfeven? (bffloor lo))
     absy]
    [else

--- a/main.scrbl
+++ b/main.scrbl
@@ -141,6 +141,8 @@ These operations have their output precision determined by
   implemented via the formula @code{(fma a b c) = (+ (* a b) c)},
   which that it accumulates multiple rounding errors. The result is
   therefore not maximally tight, but typically still pretty close.
+
+  @history[#:changed "1.7" @elem{Added @racket[ival-tgamma] and @racket[ival-lgamma]}]
 }
 
 @defproc[(ival-sort [lst (listof ival?)]

--- a/main.scrbl
+++ b/main.scrbl
@@ -117,6 +117,8 @@ These operations have their output precision determined by
   @defproc[(ival-atanh [a ival?]) ival?]
   @defproc[(ival-erf [a ival?]) ival?]
   @defproc[(ival-erfc [a ival?]) ival?]
+  @defproc[(ival-tgamma [a ival?]) ival?]
+  @defproc[(ival-lgamma [a ival?]) ival?]
   @defproc[(ival-fmod [a ival?] [b ival?]) ival?]
   @defproc[(ival-remainder [a ival?] [b ival?]) ival?]
   @defproc[(ival-rint [a ival?]) ival?]


### PR DESCRIPTION
This PR adds support for `lgamma` and `tgamma`.

It wasn't easy! The implementation is based around `convex` and `convex-find-min`, which implement interval versions of convex functions. Basically, `convex-find-min` takes in a convex bigfloat function and two endpoints, and finds the local minimum between those two endpoints using a variant of binary search. That local minimum can then be fed into `convex`.

To use this to implement the Gamma functions, note that `lgamma` is convex on all intervals between two adjacent non-positive integers, and for the positive reals. So the interval version basically splits the input into those intervals. An additional mathematical fact, that the local minima decrease as z -> -inf, is necessary for ranges that cover multiple intervals.

The implementation is probably close to sound, but it's unclear if rounding errors are handled correctly.