### PR TITLE
Fix pow for negative values and slightly better tests using constants

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -465,8 +465,9 @@
      (ival-union (mk-pow xlo yhi xhi yhi) (mk-pow xhi ylo xlo ylo))]))
 
 
+;; Assumes x is negative or zero
+;; TODO make this more precise for odd fractions
 (define (ival-pow-neg x y)
-  ;; Assumes x is negative
   (define err? (or (ival-err? x) (ival-err? y)
                    (bflt? (ival-lo-val y) (ival-hi-val y))
                    (even? (denominator (bigfloat->rational (ival-lo-val y))))

--- a/main.rkt
+++ b/main.rkt
@@ -467,6 +467,7 @@
 
 ;; Assumes x is negative or zero
 ;; TODO make this more precise for odd fractions
+;; TODO make this figure out err for even fractions
 (define (ival-pow-neg x y)
   (define err? (or (ival-err? x) (ival-err? y)
                    (bflt? (ival-lo-val y) (ival-hi-val y))

--- a/test.rkt
+++ b/test.rkt
@@ -289,6 +289,15 @@
       (check ival-contains? (ival-error? res3) #f)
       (check ival-contains? (ival-error? res3) #t)))
 
+  (test-case
+   "pow-fractional-power"
+   (for ([i (in-range num-tests)])
+     (define one-third (ival-div (ival 1.bf) (ival 3.bf)))
+     (define x (sample-interval 'real))
+     (define res (ival-pow x one-third))
+     (check-ival-valid? res)
+     (check ival-contains? res (bfcbrt (sample-from x)))))
+
   (define (sorted? list cmp)
     (cond
       [(<= (length list) 1) #t]

--- a/test.rkt
+++ b/test.rkt
@@ -190,8 +190,14 @@
 
 (define (sample-constant-interval)
   (define constants (list 0.bf 1.bf -1.bf (bf 0.5)))
-  (define c (list-ref constants (random 0 (length constants))))
-  (ival c c))
+  (define lo (list-ref constants (random 0 (length constants))))
+  (cond
+    [(= (random 0 5) 0)
+     (ival lo (bf+ lo (sample-bigfloat)))]
+    [(= (random 0 5) 0)
+     (ival (bf- lo (sample-bigfloat)) lo)]
+    [else
+     (ival lo lo)]))
 
 (define (sample-small-interval)
   ;; Biased toward small intervals

--- a/test.rkt
+++ b/test.rkt
@@ -193,9 +193,9 @@
   (define lo (list-ref constants (random 0 (length constants))))
   (cond
     [(= (random 0 5) 0)
-     (ival lo (bf+ lo (sample-bigfloat)))]
+     (ival lo (bf+ lo (bfabs (sample-bigfloat))))]
     [(= (random 0 5) 0)
-     (ival (bf- lo (sample-bigfloat)) lo)]
+     (ival (bf- lo (bfabs (sample-bigfloat))) lo)]
     [else
      (ival lo lo)]))
 


### PR DESCRIPTION
For real numbers, our interval implementation of pow was incorrect

I was able to find a bug in `tgamma` and a bug in my rust version of this library using this test.
Intervals with special constants as one of the endpoints make good tests.