### PR TITLE
Faster multiplication

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -180,7 +180,7 @@
 
 (define (classify-ival x [val #f])
   (when val (set! x (bfsub x val)))
-  (match* ((bigfloat-signbit (ival-lo-val x)) (bigfloat-signbig (ival-hi-val x)))
+  (match* ((bigfloat-signbit (ival-lo-val x)) (bigfloat-signbit (ival-hi-val x)))
     [(0 0) 1]
     [(1 1) -1]
     [(1 0) 0]))

--- a/main.rkt
+++ b/main.rkt
@@ -180,10 +180,9 @@
 
 (define (classify-ival x [val #f])
   (when val (set! x (ival-sub x (ival-expander val))))
-  (match* ((bigfloat-signbit (ival-lo-val x)) (bigfloat-signbit (ival-hi-val x)))
-    [(0 0) 1]
-    [(1 1) -1]
-    [(1 0) 0]))
+  (if (ival-err x)
+      1
+      (- 1 (bigfloat-signbit (ival-lo-val x)) (bigfloat-signbit (ival-hi-val x)))))
 
 (define (classify-ival-strict x [val 0.bf])
   (cond [(bfgt? (ival-lo-val x) val) 1] [(bflt? (ival-hi-val x) val) -1] [else 0]))

--- a/main.rkt
+++ b/main.rkt
@@ -296,19 +296,16 @@
           (rnd 'up   epmul c d x-sign y-sign)
           (or xerr? yerr?)  (or xerr yerr)))
 
-  (define x-sign (classify-ival x))
-  (define y-sign (classify-ival y))
-
-  (match* (x-sign y-sign)
-    [( 1  1) (mkmult xlo ylo xhi yhi)]
-    [( 1 -1) (mkmult xhi ylo xlo yhi)]
-    [( 1  0) (mkmult xhi ylo xhi yhi)]
-    [(-1  0) (mkmult xlo yhi xlo ylo)]
-    [(-1  1) (mkmult xlo yhi xhi ylo)]
-    [(-1 -1) (mkmult xhi yhi xlo ylo)]
-    [( 0  1) (mkmult xlo yhi xhi yhi)]
-    [( 0 -1) (mkmult xhi ylo xlo ylo)]
-    [( 0  0)
+  (match* ((bigfloat-signbit xlo) (bigfloat-signbit xhi) (bigfloat-signbit ylo) (bigfloat-signbit yhi))
+    [(0 0 0 0) (mkmult xlo ylo xhi yhi)]
+    [(0 0 1 1) (mkmult xhi ylo xlo yhi)]
+    [(0 0 1 0) (mkmult xhi ylo xhi yhi)]
+    [(1 1 1 0) (mkmult xlo yhi xlo ylo)]
+    [(1 1 0 0) (mkmult xlo yhi xhi ylo)]
+    [(1 1 1 1) (mkmult xhi yhi xlo ylo)]
+    [(1 0 0 0) (mkmult xlo yhi xhi yhi)]
+    [(1 0 1 1) (mkmult xhi ylo xlo ylo)]
+    [(1 0 1 0)
      ;; Here, the two branches of the union are meaningless on their own;
      ;; however, both branches compute possible lo/hi's to min/max together
      (ival-union (mkmult xhi ylo xlo ylo)

--- a/main.rkt
+++ b/main.rkt
@@ -179,7 +179,7 @@
    [else (split-ival i val)]))
 
 (define (classify-ival x [val #f])
-  (when val (set! x (bfsub x val)))
+  (when val (set! x (ival-sub x (ival-expander val))))
   (match* ((bigfloat-signbit (ival-lo-val x)) (bigfloat-signbit (ival-hi-val x)))
     [(0 0) 1]
     [(1 1) -1]

--- a/main.rkt
+++ b/main.rkt
@@ -494,10 +494,10 @@
   (define a (bfceiling (ival-lo-val y)))
   (define b (bffloor (ival-hi-val y)))
   (cond
-   [(bflt? b a)
+   [(bflt? b a) ; y does not contain an integer
     (if (bfzero? (ival-hi-val x))
         (ival (endpoint 0.bf #f) (endpoint 0.bf #f) #t #f)
-        (ival (endpoint +nan.bf #t) (endpoint +nan.bf #t) #t #f))]
+        (ival (endpoint +nan.bf #t) (endpoint +nan.bf #t) #t #t))]
    [(bf=? a b)
     (define aep (endpoint a (and (endpoint-immovable? (ival-lo y)) (endpoint-immovable? (ival-hi y)))))
     (if (bfodd? a)


### PR DESCRIPTION
This PR basically changes `classify-ival` to use sign bits instead of comparisons, which is much faster for the common case of comparing to 0.