### PR TITLE
Make clamping faster and more correct

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -370,15 +370,16 @@
 
 (define ((clamp lo hi) x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-  (ival (endpoint (bfmin2 (bfmax2 xlo lo) hi) xlo!)
-        (endpoint (bfmax2 (bfmin2 xhi hi) lo) xhi!)
+  
+  (ival (endpoint (if (bflt? xlo lo) lo xlo) xlo!)
+        (endpoint (if (bfgt? xhi hi) hi xhi) xhi!)
         (or xerr? (bflt? xlo lo) (bfgt? xhi hi))
         (or xerr (bflt? xhi lo) (bfgt? xlo hi))))
 
 (define ((clamp-strict lo hi) x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-  (ival (endpoint (bfmin2 (bfmax2 xlo lo) hi) xlo!)
-        (endpoint (bfmax2 (bfmin2 xhi hi) lo) xhi!)
+  (ival (endpoint (if (bflt? xlo lo) lo xlo) xlo!)
+        (endpoint (if (bfgt? xhi hi) hi xhi) xhi!)
         (or xerr? (bflte? xlo lo) (bfgte? xhi hi))
         (or xerr (bflte? xhi lo) (bfgte? xlo hi))))
 


### PR DESCRIPTION
The issue is that clamping called `bfmax2` and `bfmin2` without indicating the rounding direction, thereby accidentally rounding, possibly in the wrong direction, in case of mixed precision.