### PR TITLE
Formula change for input reduction in trig functions

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -614,9 +614,9 @@
     ['range-reduce
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
-                           (+ 10 (max
-                                  (+ (bigfloat-exponent xlo) (bigfloat-precision xlo))
-                                  (+ (bigfloat-exponent xhi) (bigfloat-precision xhi))))))])
+                           (max
+                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
+                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-floor (ival-div x (ival-pi)))))
@@ -644,9 +644,9 @@
     ['range-reduce
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
-                           (+ 10 (max
-                                  (+ (bigfloat-exponent xlo) (bigfloat-precision xlo))
-                                  (+ (bigfloat-exponent xhi) (bigfloat-precision xhi))))))])
+                           (max
+                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
+                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-round (ival-div x (ival-pi)))))
@@ -677,9 +677,9 @@
     ['range-reduce
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
-                           (+ 10 (max
-                                  (+ (bigfloat-exponent xlo) (bigfloat-precision xlo))
-                                  (+ (bigfloat-exponent xhi) (bigfloat-precision xhi))))))])
+                           (max
+                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
+                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-round (ival-div x (ival-pi)))))

--- a/main.rkt
+++ b/main.rkt
@@ -4,7 +4,7 @@
 (require (for-syntax racket/base))
 (module+ test (require rackunit))
 
-(define *rival-precision* (make-parameter 10000))
+(define *rival-precision* (make-parameter 8192))
 
 (define-match-expander ival-expander
   (λ (stx)

--- a/main.rkt
+++ b/main.rkt
@@ -4,7 +4,7 @@
 (require (for-syntax racket/base))
 (module+ test (require rackunit))
 
-(define *rival-precision* (make-parameter 8192))
+(define *rival-precision* (make-parameter 10000))
 
 (define-match-expander ival-expander
   (λ (stx)


### PR DESCRIPTION
Previously, we didn't have any dynamic parameter to determine how close an input can be to `pi`/`pi/2` when tuning range reduction in trigonometric functions. On this branch, this dynamic parameter is precision of the input, which can make the precision prediction closer to the expected one. 