### PR TITLE
Fix mixed-precision bugs

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -131,8 +131,9 @@
 (define (mk-big-ival x y)
   (cond
    [(and (bigfloat? x) (bigfloat? y))
-    (define err? (or (bfnan? x) (bfnan? y)))
     (define fix? (bf=? x y))
+    (define err? (or (bfnan? x) (bfnan? y)
+                     (and (bfinfinite? x) fix?)))
     (ival (endpoint x fix?) (endpoint y fix?) err? err?)]
    [(and (boolean? x) (boolean? y))
     (define fix? (equal? x y))

--- a/main.rkt
+++ b/main.rkt
@@ -390,14 +390,14 @@
 (define* ival-trunc (monotonic bftruncate))
 
 (define (ival-fabs x)
-  (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-  (cond
-   [(bfgt? xlo 0.bf) x]
-   [(bflt? xhi 0.bf) (ival-neg x)]
-   [else ; interval stradles 0
-    (ival (endpoint 0.bf (and xlo! xhi!))
-          (endpoint-max2 (endpoint (bfneg xlo) xlo!) (ival-hi x))
-          (ival-err? x) (ival-err x))]))
+  (match (classify-ival x)
+    [-1 ((comonotonic bfabs) x)]
+    [1 ((monotonic bfabs) x)]
+    [0
+     (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
+     (ival (endpoint 0.bf (and xlo! xhi!))
+           (rnd 'up endpoint-max2 (epfn bfabs (ival-lo x)) (ival-hi x))
+           (ival-err? x) (ival-err x))]))
 
 ;; Since MPFR has a cap on exponents, no value can be more than twice MAX_VAL
 (define exp-overflow-threshold  (bfadd (bflog (bfprev +inf.bf)) 1.bf))

--- a/main.rkt
+++ b/main.rkt
@@ -190,32 +190,22 @@
 (define (endpoint-min2 e1 e2)
   (match-define (endpoint x x!) e1)
   (match-define (endpoint y y!) e2)
-  (cond
-   [(bflt? x y)
-    e1]
-   [(bflt? y x)
-    e2]
-   [else
-    (endpoint (bfmin2 x y) (or x! y!))]))
+  (define out (bfmin2 x y))
+  (endpoint out (or (and (bf=? out x) x!) (and (bf=? out y) y!))))
 
 (define (endpoint-max2 e1 e2)
   (match-define (endpoint x x!) e1)
   (match-define (endpoint y y!) e2)
-  (cond
-   [(bfgt? x y)
-    e1]
-   [(bfgt? y x)
-    e2]
-   [else
-    (endpoint (bfmax2 x y) (or x! y!))]))
+  (define out (bfmax2 x y))
+  (endpoint out (or (and (bf=? out x) x!) (and (bf=? out y) y!))))
 
 (define (ival-union x y)
   (cond
    [(ival-err x) (struct-copy ival y [err? #t])]
    [(ival-err y) (struct-copy ival x [err? #t])]
    [(bigfloat? (ival-lo-val x))
-    (ival (endpoint-min2 (ival-lo x) (ival-lo y))
-          (endpoint-max2 (ival-hi x) (ival-hi y))
+    (ival (rnd 'down endpoint-min2 (ival-lo x) (ival-lo y))
+          (rnd 'up endpoint-max2 (ival-hi x) (ival-hi y))
           (or (ival-err? x) (ival-err? y)) (and (ival-err x) (ival-err y)))]
    [(boolean? (ival-lo-val x))
     (ival (epfn and-fn (ival-lo x) (ival-lo y))

--- a/main.rkt
+++ b/main.rkt
@@ -212,11 +212,6 @@
           (epfn or-fn (ival-hi x) (ival-hi y))
           (or (ival-err? x) (ival-err? y)) (and (ival-err x) (ival-err y)))]))
 
-(define (propagate-err c x)
-  (ival (ival-lo x) (ival-hi x)
-        (or (ival-err? c) (ival-err? x))
-        (or (ival-err c) (ival-err x))))
-
 ;; This function computes and propagates the immovable? flag for endpoints
 (define (epfn op . args)
   (define args-bf (map endpoint-val args))
@@ -1002,11 +997,13 @@
         (or (ival-err? a) (ormap ival-err? as))
         (or (ival-err a) (ormap ival-err as))))
 
+(define* ival-identity (monotonic bfcopy))
+
 (define (ival-if c x y)
   (cond
-   [(ival-lo-val c) (propagate-err c x)]
-   [(not (ival-hi-val c)) (propagate-err c y)]
-   [else (propagate-err c (ival-union x y))]))
+   [(ival-lo-val c) (ival-then c (ival-identity x))]
+   [(not (ival-hi-val c)) (ival-then c (ival-identity y))]
+   [else (ival-then c (ival-union x y))]))
 
 (define (ival-fmin x y)
   (ival (rnd 'down endpoint-min2 (ival-lo x) (ival-lo y))

--- a/main.rkt
+++ b/main.rkt
@@ -4,7 +4,7 @@
 (require (for-syntax racket/base))
 (module+ test (require rackunit))
 
-(define *rival-precision* (make-parameter 8192))
+(define *rival-precision* (make-parameter (expt 2 20)))
 
 (define-match-expander ival-expander
   (λ (stx)

--- a/main.rkt
+++ b/main.rkt
@@ -1009,11 +1009,13 @@
    [else (propagate-err c (ival-union x y))]))
 
 (define (ival-fmin x y)
-  (ival (endpoint-min2 (ival-lo x) (ival-lo y)) (endpoint-min2 (ival-hi x) (ival-hi y))
+  (ival (rnd 'down endpoint-min2 (ival-lo x) (ival-lo y))
+        (rnd 'up endpoint-min2 (ival-hi x) (ival-hi y))
         (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
 
 (define (ival-fmax x y)
-  (ival (endpoint-max2 (ival-lo x) (ival-lo y)) (endpoint-max2 (ival-hi x) (ival-hi y))
+  (ival (rnd 'down endpoint-max2 (ival-lo x) (ival-lo y))
+        (rnd 'up endpoint-max2 (ival-hi x) (ival-hi y))
         (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
 
 (define (ival-copysign x y)

--- a/main.rkt
+++ b/main.rkt
@@ -351,11 +351,15 @@
 
 (define ((clamp lo hi) x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
+  (define err? (or xerr? (bflt? xlo lo) (bfgt? xhi hi)))
+  (define err (or (or xerr (bflt? xhi lo) (bfgt? xlo hi))))
   
-  (ival (endpoint (if (bflt? xlo lo) lo xlo) xlo!)
-        (endpoint (if (bfgt? xhi hi) hi xhi) xhi!)
-        (or xerr? (bflt? xlo lo) (bfgt? xhi hi))
-        (or xerr (bflt? xhi lo) (bfgt? xlo hi))))
+  (if (and (bfzero? lo) (bfzero? xhi))
+      (ival (endpoint 0.bf xlo!) (endpoint 0.bf xhi!) err? err)
+      (ival (endpoint (if (bflt? xlo lo) lo xlo) xlo!)
+            (endpoint (if (bfgt? xhi hi) hi xhi) xhi!)
+            err?
+            err)))
 
 (define ((clamp-strict lo hi) x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)

--- a/test.rkt
+++ b/test.rkt
@@ -242,9 +242,10 @@
            (value-equals? (ival-hi ival1) (ival-hi ival2)))))
 
 (define num-tests 1000)
-(define num-slow-tests 25)
 (define num-witnesses 10)
+
 (define slow-tests (list ival-lgamma ival-tgamma))
+(define num-slow-tests 25)
 
 (define (test-entry ival-fn fn args)
   (define out-prec (sample-precision))
@@ -340,15 +341,18 @@
 (module+ main
   (require racket/cmdline)
   (command-line
-   #:args (fname [n (~a num-tests)])
-   (define entry
-     (findf (λ (entry) (equal? (~a (object-name (first entry))) (format "ival-~a" fname)))
-            function-table))
-   (match entry
-     [#f
-      (raise-user-error 'test.rkt "No function named ival-~a" fname)]
-     [(list ival-fn fn itypes otype)
-      (for ([n (in-range (string->number n))])
-        (test-entry ival-fn fn itypes)
-        (eprintf "."))
-      (newline)])))
+   #:args ([fname #f] [n (~a num-tests)])
+   (cond
+     [fname
+      (define entry
+        (findf (λ (entry) (equal? (~a (object-name (first entry))) (format "ival-~a" fname)))
+               function-table))
+      (match entry
+        [#f
+         (raise-user-error 'test.rkt "No function named ival-~a" fname)]
+        [(list ival-fn fn itypes otype)
+         (for ([n (in-range (string->number n))])
+           (test-entry ival-fn fn itypes)
+           (eprintf "."))
+         (newline)])]
+     [else (run-tests)])))

--- a/test.rkt
+++ b/test.rkt
@@ -58,7 +58,9 @@
   (bffloor (bflog2 (bfabs x))))
 
 (define (bfcopysign x y)
-  (bf* (bfabs x) (if (= (bigfloat-signbit y) 1) -1.bf 1.bf)))
+  (if (bfnan? y)
+      +nan.bf
+      (bf* (bfabs x) (if (= (bigfloat-signbit y) 1) -1.bf 1.bf))))
 
 (define (bffdim x y)
   (if (bf> x y) (bf- x y) 0.bf))

--- a/test.rkt
+++ b/test.rkt
@@ -80,7 +80,7 @@
     (define precision
       (+ (bf-precision) (max (- (+ (bigfloat-exponent x) (bigfloat-precision x))
                                 (+ (bigfloat-exponent mod) (bigfloat-precision mod))) 0)))
-    (if (< precision (expt 2 25)) ; Limit it to 32MB per number
+    (if (< precision (expt 2 20)) ; Limit it to 1MB per number
         (bfcopy
          (parameterize ([bf-precision precision]) 
            (bfcanonicalize (bf- x (bf* (bftruncate (bf/ x mod)) mod)))))

--- a/test.rkt
+++ b/test.rkt
@@ -81,8 +81,9 @@
       (+ (bf-precision) (max (- (+ (bigfloat-exponent x) (bigfloat-precision x))
                                 (+ (bigfloat-exponent mod) (bigfloat-precision mod))) 0)))
     (if (< precision (expt 2 25)) ; Limit it to 32MB per number
-        (parameterize ([bf-precision precision]) 
-          (bfcanonicalize (bf- x (bf* (bftruncate (bf/ x mod)) mod))))
+        (bfcopy
+         (parameterize ([bf-precision precision]) 
+           (bfcanonicalize (bf- x (bf* (bftruncate (bf/ x mod)) mod)))))
         ;; By chance this is treated as either valid or invalid as needed
         +inf.bf)]))
 
@@ -262,7 +263,7 @@
                (parameterize ([bf-precision in-prec])
                  (sample-from i))))
     (set! y (parameterize ([bf-precision out-prec]) (apply fn xs)))
-    (with-check-info (['intervals is] ['points xs])
+    (with-check-info (['intervals is] ['points xs] ['in-precs in-precs] ['out-prec out-prec])
       (check ival-contains? iy y)))
 
   (with-check-info (['intervals is] ['points xs] ['iy iy] ['y y])

--- a/test.rkt
+++ b/test.rkt
@@ -78,7 +78,8 @@
    [else
     ;; For this to be precise, we need enough bits
     (define precision
-      (+ (bf-precision) (max (- (bigfloat-exponent x) (bigfloat-exponent mod)) 0)))
+      (+ (bf-precision) (max (- (+ (bigfloat-exponent x) (bigfloat-precision x))
+                                (+ (bigfloat-exponent mod) (bigfloat-precision mod))) 0)))
     (if (< precision (expt 2 25)) ; Limit it to 32MB per number
         (parameterize ([bf-precision precision]) 
           (bfcanonicalize (bf- x (bf* (bftruncate (bf/ x mod)) mod))))


### PR DESCRIPTION
This PR fixes a load of soundness bugs that affected various function when run in mixed-precision mode (that is, when output and input precisions didn't match). It also adds new tests, and then fixes a bunch of bugs that those tests found.