### PR TITLE
Trig exponent calculation fix

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -583,6 +583,12 @@
                       'range-reduce)
                   'range-reduce)))))
 
+(define (bfexponent x)
+  (define exp (+ (bigfloat-exponent x) (bigfloat-precision x)))
+  (if (< 1000000000 (abs exp))
+      0  ; overflow/inf.bf/nan.bf/0.bf
+      exp))
+
 (define (ival-cos x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
   
@@ -600,8 +606,8 @@
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
                            (max
-                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
-                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
+                            (+ (bfexponent xlo) (bigfloat-precision xlo))
+                            (+ (bfexponent xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-floor (ival-div x (ival-pi)))))
@@ -630,8 +636,8 @@
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
                            (max
-                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
-                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
+                            (+ (bfexponent xlo) (bigfloat-precision xlo))
+                            (+ (bfexponent xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-round (ival-div x (ival-pi)))))
@@ -663,8 +669,8 @@
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
                            (max
-                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
-                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
+                            (+ (bfexponent xlo) (bigfloat-precision xlo))
+                            (+ (bfexponent xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-round (ival-div x (ival-pi)))))

--- a/main.rkt
+++ b/main.rkt
@@ -583,12 +583,6 @@
                       'range-reduce)
                   'range-reduce)))))
 
-(define (bfexponent x)
-  (define exp (+ (bigfloat-exponent x) (bigfloat-precision x)))
-  (if (< 1000000000 (abs exp))
-      0  ; overflow/inf.bf/nan.bf/0.bf
-      exp))
-
 (define (ival-cos x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
   

--- a/main.rkt
+++ b/main.rkt
@@ -540,9 +540,9 @@
   (if (<= lo* 0)    ; if lo* belongs to (-1, 1)
       (if (<= hi* 0)    ; if hi* belongs to (-1, 1)
                         ; -9223372036854775807 is a code for 0.bf, otherwise -9220000000000000000 and lower is a nan/inf
-          (if (or (and (> -9220000000000000000 lo*) (not (equal? -9223372036854775807 lo*)))
-                  (and (> -9220000000000000000 hi*) (not (equal? -9223372036854775807 hi*))))
-              'too-wide    ; interval includes inf/nan
+          (if (or (and (< 1073741822 (abs lo*)) (not (equal? -9223372036854775807 lo*)))
+                  (and (< 1073741822 (abs hi*)) (not (equal? -9223372036854775807 hi*))))
+              'too-wide    ; interval includes inf/nan/overflow
               'near-0) 
           (cond
             [(equal? period 'pi)
@@ -606,8 +606,8 @@
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
                            (max
-                            (+ (bfexponent xlo) (bigfloat-precision xlo))
-                            (+ (bfexponent xhi) (bigfloat-precision xhi)))))])
+                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
+                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-floor (ival-div x (ival-pi)))))
@@ -636,8 +636,8 @@
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
                            (max
-                            (+ (bfexponent xlo) (bigfloat-precision xlo))
-                            (+ (bfexponent xhi) (bigfloat-precision xhi)))))])
+                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
+                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-round (ival-div x (ival-pi)))))
@@ -669,8 +669,8 @@
      (let ([prec (min (*rival-precision*)
                       (max (bf-precision)
                            (max
-                            (+ (bfexponent xlo) (bigfloat-precision xlo))
-                            (+ (bfexponent xhi) (bigfloat-precision xhi)))))])
+                            (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
+                            (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi)))))])
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision prec])
            (ival-round (ival-div x (ival-pi)))))


### PR DESCRIPTION
This pull request fixes the bug that is associated with exponent calculation for constant `bf` values. Range reduction used to be evaluated with `*rival-precision*` bits of precision because exponent calculations for some constants were not wrong. These constants are:  `-inf.bf +inf.bf +nan.bf -min.bf -max.bf +min.bf +max.bf` - range reduction is redundant, the interval is `'too-wide`