### PR TITLE
Range reduction fix2

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -537,51 +537,51 @@
   (define lo* (+ (bigfloat-exponent xlo) (bigfloat-precision xlo)))
   (define hi* (+ (bigfloat-exponent xhi) (bigfloat-precision xhi)))
 
-  (if (<= lo* 0)    ; if lo* belongs to (-1, 1)
-      (if (<= hi* 0)    ; if hi* belongs to (-1, 1)
-                        ; -9223372036854775807 is a code for 0.bf, otherwise 1000000000 and higher is a nan/inf/overflow
-          (if (or (and (< 1000000000 (abs lo*)) (not (equal? -9223372036854775807 lo*)))
-                  (and (< 1000000000 (abs hi*)) (not (equal? -9223372036854775807 hi*))))
-              'too-wide    ; interval includes inf/nan/overflow
-              'near-0) 
-          (cond
-            [(equal? period 'pi)
-             (if (>= hi* 2)    ; if hi* belongs to (-inf, -2] U [2, +inf)
-                 'too-wide
-                 'range-reduce)]
-            [(equal? period '2pi)
-             (if (>= hi* 4)    ; if hi* belongs to (-inf, -8] U [8, +inf)
-                 'too-wide
-                 'range-reduce)]))
-      (if (<= lo* 1)    ; if lo* belongs to (-2, 2)
-          (cond
-            [(equal? period 'pi)
-             (if (>= hi* 4)    ; if hi* belongs to (-inf, -8] U [8, +inf)
-                 'too-wide
-                 'range-reduce)]
-            [(equal? period '2pi)
-             (if (>= hi* 5)    ; if hi* belongs to (-inf, -16] U [16, +inf)
-                 'too-wide
-                 'range-reduce)])
-          (if (<= lo* 2)  ; if lo* belongs to (-4, 4)
+  
+  (if (or (and (< 1073741822 (abs lo*)) (not (equal? -9223372036854775807 lo*)))  ; -9223372036854775807 is a code for 0.bf
+          (and (< 1073741822 (abs hi*)) (not (equal? -9223372036854775807 hi*)))) ; |lo* or hi*| > 1073741822 is nan/inf/overflow 
+      'too-wide                     ; overflow/inf/nan
+      (if (<= lo* 0)                ; if lo* belongs to (-1, 1)
+          (if (<= hi* 0)            ; if hi* belongs to (-1, 1)  
+              'near-0
               (cond
                 [(equal? period 'pi)
-                 (if (>= hi* 4)    ; if hi* belongs to (-inf, -8] U [8, +inf)
+                 (if (>= hi* 2)     ; if hi* belongs to (-inf, -2] U [2, +inf)
                      'too-wide
                      'range-reduce)]
                 [(equal? period '2pi)
-                 (if (>= hi* 5)    ; if hi* belongs to (-inf, -16] U [16, +inf)
+                 (if (>= hi* 4)     ; if hi* belongs to (-inf, -8] U [8, +inf)
+                     'too-wide
+                     'range-reduce)]))
+          (if (<= lo* 1)            ; if lo* belongs to (-2, 2)
+              (cond
+                [(equal? period 'pi)
+                 (if (>= hi* 4)     ; if hi* belongs to (-inf, -8] U [8, +inf)
+                     'too-wide
+                     'range-reduce)]
+                [(equal? period '2pi)
+                 (if (>= hi* 5)     ; if hi* belongs to (-inf, -16] U [16, +inf)
                      'too-wide
                      'range-reduce)])
-              (if (>= lo* 3)  ; if lo* belongs to (-inf, -4] U [4, +inf)
-                  (if (>= hi* 3)  ; if hi* belongs to (-inf, -4] U [4, +inf)
-                      (if (> (abs (- hi* lo*)) 1)
-                          'too-wide
-                          (if (equal? (bigfloat-signbit xlo) (bigfloat-signbit xhi))
-                              'range-reduce
-                              'too-wide))
-                      'range-reduce)
-                  'range-reduce)))))
+              (if (<= lo* 2)        ; if lo* belongs to (-4, 4)
+                  (cond
+                    [(equal? period 'pi)
+                     (if (>= hi* 4) ; if hi* belongs to (-inf, -8] U [8, +inf)
+                         'too-wide
+                         'range-reduce)]
+                    [(equal? period '2pi)
+                     (if (>= hi* 5) ; if hi* belongs to (-inf, -16] U [16, +inf)
+                         'too-wide
+                         'range-reduce)])
+                  (if (>= lo* 3)    ; if lo* belongs to (-inf, -4] U [4, +inf)
+                      (if (>= hi* 3) ; if hi* belongs to (-inf, -4] U [4, +inf)
+                          (if (> (abs (- hi* lo*)) 1)
+                              'too-wide
+                              (if (equal? (bigfloat-signbit xlo) (bigfloat-signbit xhi))
+                                  'range-reduce
+                                  'too-wide))
+                          'range-reduce)
+                      'range-reduce))))))
 
 (define (ival-cos x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)

--- a/main.rkt
+++ b/main.rkt
@@ -539,9 +539,9 @@
 
   (if (<= lo* 0)    ; if lo* belongs to (-1, 1)
       (if (<= hi* 0)    ; if hi* belongs to (-1, 1)
-                        ; -9223372036854775807 is a code for 0.bf, otherwise -9220000000000000000 and lower is a nan/inf
-          (if (or (and (< 1073741822 (abs lo*)) (not (equal? -9223372036854775807 lo*)))
-                  (and (< 1073741822 (abs hi*)) (not (equal? -9223372036854775807 hi*))))
+                        ; -9223372036854775807 is a code for 0.bf, otherwise 1000000000 and higher is a nan/inf/overflow
+          (if (or (and (< 1000000000 (abs lo*)) (not (equal? -9223372036854775807 lo*)))
+                  (and (< 1000000000 (abs hi*)) (not (equal? -9223372036854775807 hi*))))
               'too-wide    ; interval includes inf/nan/overflow
               'near-0) 
           (cond


### PR DESCRIPTION
The same fix as #21, but unfortunately I fixed exponent calculation for only a single conditional branch of the body, when the fix actually has to be at the top of the body. Now fixed, bug removed