### PR TITLE
Exact ival-fabs ival-neg

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -992,7 +992,7 @@
         (or (ival-err? x) (ival-err? y)) (or (ival-err x) (ival-err y))))
 
 (define (ival-copysign x y)
-  (match-define (ival xlo xhi xerr? xerr) (ival-exact-fabs x))
+  (match-define (ival xlo xhi xerr? xerr) (ival-fabs x))
   (define can-zero
     (or (bfzero? (ival-lo-val y)) (bfzero? (ival-hi-val y))))
   ;; 0 is both positive and negative because we don't handle signed zero well

--- a/main.rkt
+++ b/main.rkt
@@ -695,7 +695,7 @@
       (ival (endpoint 0.bf #f)
             (endpoint (rnd 'up bfmax2 (bfdiv (ival-hi-val x) (bfadd c 1.bf)) 0.bf) #f) err? err)])]
    [else
-    (ival (endpoint 0.bf #f) (endpoint (rnd 'up bfabs (ival-hi-val y)) #f) err? err)]))
+    (ival (endpoint 0.bf #f) (endpoint (ival-hi-val y) #f) err? err)]))
 
 (define (ival-fmod x y)
   (define err? (or (ival-err? x) (ival-err? y)

--- a/main.rkt
+++ b/main.rkt
@@ -695,7 +695,7 @@
       (ival (endpoint 0.bf #f)
             (endpoint (rnd 'up bfmax2 (bfdiv (ival-hi-val x) (bfadd c 1.bf)) 0.bf) #f) err? err)])]
    [else
-    (ival (endpoint 0.bf #f) (endpoint (ival-hi-val y) #f) err? err)]))
+    (ival (endpoint 0.bf #f) (endpoint (rnd 'up bfabs (ival-hi-val y)) #f) err? err)]))
 
 (define (ival-fmod x y)
   (define err? (or (ival-err? x) (ival-err? y)

--- a/test.rkt
+++ b/test.rkt
@@ -34,7 +34,16 @@
 (define (value-equals? bf1 bf2)
   (if (boolean? bf1)
       (equal? bf1 bf2)
-      (or (bf= bf1 bf2) (and (bfnan? bf1) (bfnan? bf2)))))
+      (or (bigfloats-equal? bf1 bf2) (and (bfnan? bf1) (bfnan? bf2)))))
+
+(define (bigfloats-equal? x y)
+  (cond
+     [(< (bigfloat-precision x) (bigfloat-precision y))
+      (bf= x (parameterize ([bf-rounding-mode 'nearest] [bf-precision (bigfloat-precision x)]) (bfcopy y)))]
+     [(> (bigfloat-precision x) (bigfloat-precision y))
+      (bf= y (parameterize ([bf-rounding-mode 'nearest] [bf-precision (bigfloat-precision y)]) (bfcopy x)))]
+     [else (bf= y x)]))
+    
 
 (define (value-lte? bf1 bf2)
   (if (boolean? bf1)

--- a/test.rkt
+++ b/test.rkt
@@ -31,17 +31,17 @@
            (or (equal? pt (ival-lo ival))
                (equal? pt (ival-hi ival))))))
 
-(define (value-equals? bf1 bf2)
+(define (value-equals? bf1 bf2 [rnd-mode 'nearest])
   (if (boolean? bf1)
       (equal? bf1 bf2)
-      (or (bigfloats-equal? bf1 bf2) (and (bfnan? bf1) (bfnan? bf2)))))
+      (or (bigfloats-equal? bf1 bf2 rnd-mode) (and (bfnan? bf1) (bfnan? bf2)))))
 
-(define (bigfloats-equal? x y)
+(define (bigfloats-equal? x y rnd-mode)
   (cond
      [(< (bigfloat-precision x) (bigfloat-precision y))
-      (bf= x (parameterize ([bf-rounding-mode 'nearest] [bf-precision (bigfloat-precision x)]) (bfcopy y)))]
+      (bf= x (parameterize ([bf-rounding-mode rnd-mode] [bf-precision (bigfloat-precision x)]) (bfcopy y)))]
      [(> (bigfloat-precision x) (bigfloat-precision y))
-      (bf= y (parameterize ([bf-rounding-mode 'nearest] [bf-precision (bigfloat-precision y)]) (bfcopy x)))]
+      (bf= y (parameterize ([bf-rounding-mode rnd-mode] [bf-precision (bigfloat-precision y)]) (bfcopy x)))]
      [else (bf= y x)]))
     
 
@@ -271,8 +271,8 @@
 (define-binary-check (check-ival-equals? ival1 ival2)
   (if (ival-err ival1)
       (ival-err ival2)
-      (and (value-equals? (ival-lo ival1) (ival-lo ival2))
-           (value-equals? (ival-hi ival1) (ival-hi ival2)))))
+      (and (value-equals? (ival-lo ival1) (ival-lo ival2) 'down)
+           (value-equals? (ival-hi ival1) (ival-hi ival2) 'up))))
 
 (define num-tests 1000)
 (define num-witnesses 10)


### PR DESCRIPTION
This branch introduces two new function called `ival-exact-fabs` and `ival-exact-neg`. These functions work the same as their "inexact" copies - the main difference is - the result of the new functions is evaluated under the precision of input.
Some functions require `exact` versions for correctness, they are: `ival-fmod`, `ival-remainder` and etc.