### PR TITLE
Fmod fix

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -678,7 +678,7 @@
 
 (define (ival-fmod-pos x y err? err)
   ;; Assumes both `x` and `y` are entirely positive
-  (define precision (max (ival-max-prec x) (ival-max-prec y)))
+  (define precision (max (bf-precision) (ival-max-prec x) (ival-max-prec y)))
   (define a (parameterize ([bf-precision precision])
               (rnd 'down bftruncate (bfdiv (ival-lo-val x) (ival-hi-val y)))))
   (define b (parameterize ([bf-precision precision])
@@ -700,9 +700,9 @@
             err? err)]
      [else
       (ival (endpoint 0.bf #f)
-            (endpoint (rnd 'up bfmax2 (parameterize ([bf-precision precision])
-                                        (bfdiv (ival-hi-val x) (bfadd c 1.bf)))
-                                        0.bf) #f) err? err)])]
+            (endpoint (rnd 'up bfmax2 (bfdiv (ival-hi-val x) 
+                                             (parameterize ([bf-precision precision]) (bfadd c 1.bf)))
+                           0.bf) #f) err? err)])]
    [else
     (ival (endpoint 0.bf #f) (endpoint (ival-hi-val y) #f) err? err)]))
 

--- a/main.rkt
+++ b/main.rkt
@@ -700,8 +700,8 @@
             err? err)]
      [else
       (ival (endpoint 0.bf #f)
-            (endpoint (rnd 'up bfmax2 (bfdiv (ival-hi-val x) 
-                                             (parameterize ([bf-precision precision]) (bfadd c 1.bf)))
+            (endpoint (rnd 'up bfmax2 (parameterize ([bf-precision precision]) (bfdiv (ival-hi-val x) 
+                                                                                      (bfadd c 1.bf)))
                            0.bf) #f) err? err)])]
    [else
     (ival (endpoint 0.bf #f) (endpoint (ival-hi-val y) #f) err? err)]))

--- a/test.rkt
+++ b/test.rkt
@@ -26,8 +26,12 @@
         true]
        [else
         (and (not (ival-err ival))
-             (bf<= (ival-lo ival) (parameterize ([bf-precision (bigfloat-precision (ival-lo ival))] [bf-rounding-mode 'down]) (bfcopy pt))) 
-             (bf<= (parameterize ([bf-precision (bigfloat-precision (ival-lo ival))] [bf-rounding-mode 'up]) (bfcopy pt)) (ival-hi ival)))])
+             (if (equal? (bigfloat-precision pt) (bigfloat-precision (ival-lo ival))) 
+                 (bf<= (ival-lo ival) pt)
+                 (bf<= (parameterize ([bf-precision (bigfloat-precision pt)] [bf-rounding-mode 'down]) (bfcopy (ival-lo ival))) pt))
+             (if (equal? (bigfloat-precision pt) (bigfloat-precision (ival-hi ival))) 
+                 (bf<= pt (ival-hi ival))
+                 (bf<= pt (parameterize ([bf-precision (bigfloat-precision pt)] [bf-rounding-mode 'up]) (bfcopy (ival-hi ival))))))])
       (and (not (ival-err ival))
            (or (equal? pt (ival-lo ival))
                (equal? pt (ival-hi ival))))))

--- a/test.rkt
+++ b/test.rkt
@@ -26,7 +26,8 @@
         true]
        [else
         (and (not (ival-err ival))
-             (bf<= (ival-lo ival) pt) (bf<= pt (ival-hi ival)))])
+             (bf<= (ival-lo ival) (parameterize ([bf-precision (bigfloat-precision (ival-lo ival))] [bf-rounding-mode 'down]) (bfcopy pt))) 
+             (bf<= (parameterize ([bf-precision (bigfloat-precision (ival-lo ival))] [bf-rounding-mode 'up]) (bfcopy pt)) (ival-hi ival)))])
       (and (not (ival-err ival))
            (or (equal? pt (ival-lo ival))
                (equal? pt (ival-hi ival))))))


### PR DESCRIPTION
This branch fixes the issue that was observed on nightly from Herbie run - `ival-fmod` didn't work quite well with tuning - the inputs could be 8000bits of precision but working precision 94bits didn't produce a fixed result.
This bug is fixed and now the workflow does not lose much accuracy.
This branch also fixes an issue with `ival-contains` in the tests when the inputs are in different precision (usually `ival` may have higher precision) the point is rounded to the lower precision