### PR TITLE
Speed up `classify-ival`

### DIFF
--- a/ops.rkt
+++ b/ops.rkt
@@ -128,8 +128,8 @@
 
 (define (classify-ival-strict x)
   (cond
-    [(= (mpfr-sign (ival-lo-val x)) 1) 1]
-    [(= (mpfr-sign (ival-hi-val x)) -1) -1]
+    [(and (= (mpfr-sign (ival-lo-val x)) 1) (not (bfzero? (ival-lo-val x)))) 1]
+    [(and (= (mpfr-sign (ival-hi-val x)) -1) (not (bfzero? (ival-hi-val x)))) -1]
     [else 0]))
 
 (define (endpoint-min2 e1 e2)


### PR DESCRIPTION
This PR combines two core optimizations:

- Use `mpfr-sign` (a struct accessor) instead of `bf-signbit` (a confusing wrapper around it)
- Specialize `classify-ival` for the use case in `pow` where we need to classify positive intervals for bigger/smaller than 1
- Specialize `classify-ival-strict` for the only use case of classifying around 0