### PR TITLE
Various improvements to the nightlies

### DIFF
--- a/time.rkt
+++ b/time.rkt
@@ -113,6 +113,8 @@
     (define count-u 0.0)
 
     (for ([rec (in-port read-json p)] [i (in-naturals)] #:unless (and test-id (not (= i test-id))))
+      (when test-id
+        (pretty-print (map read-from-string (hash-ref rec 'exprs))))
       (match-define (list c-time v-num v-time i-num i-time u-num u-time)
         (time-exprs (time-expr rec)))
       (set! total-c (+ total-c c-time))

--- a/time.rkt
+++ b/time.rkt
@@ -71,47 +71,50 @@
         (length (hash-ref times 'unsamplable '()))
         (/ (apply + (hash-ref times 'unsamplable '())) 1000)))
 
-(define (run html? p)
-  (when html?
-    (printf "<!doctype html>")
-    (printf "<h1>Operation timings</h1>")
-    (printf "<table>")
-    (printf "<thead><tr><th>Operation<th colspan=2>Time ([min, max])")
-    (printf "<tbody>"))
-  (for ([rec (in-list (time-operations))])
-    (match-define (list ival-fn avg se) rec)
-    (define min-s (~r (* (- avg se se) 1000) #:precision '(= 3)))
-    (define max-s (~r (* (+ avg se se) 1000) #:precision '(= 3)))
-    (cond
-      [html?
-       (printf "<tr><td><code>~a</code></td>" (object-name ival-fn))
-       (printf "<td>~aµs<td>~aµs" min-s max-s)]
-      [else
-       (printf "~a [~a, ~a]µs\n"
-            (~a (object-name ival-fn) #:align 'left #:min-width 20)
-            (~a min-s #:min-width 8)
-            (~a max-s #:min-width 8))]))
-  (when html?
-    (printf "</table>"))
+(define (run html? test-id p)
+  (when html? (printf "<!doctype html>"))
+  
+  (unless test-id
+    (when html?
+      (printf "<h1>Operation timings</h1>")
+      (printf "<table>")
+      (printf "<thead><tr><th>Operation<th colspan=2>Time ([min, max])")
+      (printf "<tbody>"))
+    (for ([rec (in-list (time-operations))])
+      (match-define (list ival-fn avg se) rec)
+      (define min-s (~r (* (- avg se se) 1000) #:precision '(= 3)))
+      (define max-s (~r (* (+ avg se se) 1000) #:precision '(= 3)))
+      (cond
+        [html?
+         (printf "<tr><td><code>~a</code></td>" (object-name ival-fn))
+         (printf "<td>~aµs<td>~aµs" min-s max-s)]
+        [else
+         (printf "~a [~a, ~a]µs\n"
+              (~a (object-name ival-fn) #:align 'left #:min-width 20)
+              (~a min-s #:min-width 8)
+              (~a max-s #:min-width 8))]))
+    (when html?
+      (printf "</table>")))
 
   (when p
     (cond
       [html?
        (printf "<h1>Expression Timing</h1>")
        (printf "<table>")
-       (printf "<thead><tr><th>#<th>Compile (ms)<th colspan=2>Valid (#, ms)<th colspan=2>Invalid (#, ms)<th colspan=2>Unsamplable (#, ms)</thead>")]
+       (printf "<thead><tr><th>#<th>Time (s)<th>Compile (s)<th colspan=2>Valid (#, s)<th colspan=2>Invalid (#, s)<th colspan=2>Unsamplable (#, s)</thead>")]
       [else
        (newline)])
     (define total-t 0.0)
 
-    (for ([rec (in-port read-json p)] [i (in-naturals)])
+    (for ([rec (in-port read-json p)] [i (in-naturals)] #:unless (and test-id (not (= i test-id))))
       (match-define (list c-time v-num v-time i-num i-time u-num u-time)
         (time-exprs (time-expr rec)))
       (set! total-t (+ total-t c-time v-time i-time u-time))
       
       (cond
         [html?
-         (printf "<tr><td>~a<td>~as" i (~r c-time #:precision '(= 3)))
+         (printf "<tr><td>~a<td>~as" i (+ c-time v-time i-time u-time))
+         (printf "<td>~a" (~r c-time #:precision '(= 3)))
          (printf "<td>~a<td>~as" v-num (~r v-time #:precision '(= 3)))
          (printf "<td>~a<td>~as" i-num (~r i-time #:precision '(= 3)))
          (printf "<td>~a<td>~as" u-num (~r u-time #:precision '(= 3)))]
@@ -129,17 +132,20 @@
     (cond
       [html?
        (printf "</table>")
-       (printf "<dl><dt>Total Time:</dt><dd>~as</dd></dl>" (~r (/ total-t 1000) #:precision '(= 3)))]
+       (printf "<dl><dt>Total Time:</dt><dd>~as</dd></dl>" (~r total-t #:precision '(= 3)))]
       [else
-       (printf "\nTotal Time: ~as\n" (~r (/ total-t 1000) #:precision '(= 3)))])))
+       (printf "\nTotal Time: ~as\n" (~r total-t #:precision '(= 3)))])))
 
 
 (module+ main
   (require racket/cmdline)
   (define html? #f)
+  (define n #f)
   (command-line
    #:once-each
    [("--html") "Produce HTML output"
                (set! html? #t)]
+   [("--id") ns "Run a single test"
+             (set! n (string->number ns))]
    #:args ([points "infra/points.json"])
-   (run html? (open-input-file points))))
+   (run html? n (open-input-file points))))

--- a/time.rkt
+++ b/time.rkt
@@ -104,20 +104,38 @@
        (printf "<thead><tr><th>#<th>Time (s)<th>Compile (s)<th colspan=2>Valid (#, s)<th colspan=2>Invalid (#, s)<th colspan=2>Unsamplable (#, s)</thead>")]
       [else
        (newline)])
-    (define total-t 0.0)
+    (define total-c 0.0)
+    (define total-v 0.0)
+    (define count-v 0.0)
+    (define total-i 0.0)
+    (define count-i 0.0)
+    (define total-u 0.0)
+    (define count-u 0.0)
 
     (for ([rec (in-port read-json p)] [i (in-naturals)] #:unless (and test-id (not (= i test-id))))
       (match-define (list c-time v-num v-time i-num i-time u-num u-time)
         (time-exprs (time-expr rec)))
-      (set! total-t (+ total-t c-time v-time i-time u-time))
+      (set! total-c (+ total-c c-time))
+      (set! total-v (+ total-v v-time))
+      (set! count-v (+ count-v v-num))
+      (set! total-i (+ total-i i-time))
+      (set! count-i (+ count-i i-num))
+      (set! total-u (+ total-u u-time))
+      (set! count-u (+ count-u u-num))
       
       (cond
         [html?
          (printf "<tr><td>~a<td>~as" i (+ c-time v-time i-time u-time))
          (printf "<td>~a" (~r c-time #:precision '(= 3)))
-         (printf "<td>~a<td>~as" v-num (~r v-time #:precision '(= 3)))
-         (printf "<td>~a<td>~as" i-num (~r i-time #:precision '(= 3)))
-         (printf "<td>~a<td>~as" u-num (~r u-time #:precision '(= 3)))]
+         (if (> v-num 0)
+             (printf "<td>~a<td>~as" v-num (~r v-time #:precision '(= 3)))
+             (printf "<td><td>"))
+         (if (> i-num 0)
+             (printf "<td>~a<td>~as" i-num (~r i-time #:precision '(= 3)))
+             (printf "<td><td>"))
+         (if (> u-num 0)
+             (printf "<td>~a<td>~as" u-num (~r u-time #:precision '(= 3)))
+             (printf "<td><td>"))]
         [else
          (printf "~a ~ams v(~a: ~ams) i(~a: ~ams) u(~a: ~ams)\n"
                  (~a i #:align 'left #:min-width 3)
@@ -131,10 +149,16 @@
 
     (cond
       [html?
-       (printf "</table>")
-       (printf "<dl><dt>Total Time:</dt><dd>~as</dd></dl>" (~r total-t #:precision '(= 3)))]
+       (printf "<tbody><tr><td>Total<td>~a<td>~a"
+               (~r (+ total-c total-v total-i total-u) #:precision '(= 3))
+               (~r total-c #:precision '(= 3)))
+       (printf "<td><td>~a<td><td>~a<td><td>~a"
+               (~r total-v #:precision '(= 3))
+               (~r total-i #:precision '(= 3))
+               (~r total-u #:precision '(= 3)))
+       (printf "</table>")]
       [else
-       (printf "\nTotal Time: ~as\n" (~r total-t #:precision '(= 3)))])))
+       (printf "\nTotal Time: ~as\n" (~r (+ total-c total-v total-i total-u) #:precision '(= 3)))])))
 
 
 (module+ main


### PR DESCRIPTION
This PR adds a "total" row at the foot of the table, so we can see the contribution to the total from unsamplable, valid, and invalid points. There's also an `--id` flag that lets you rerun a single benchmark on the command line, for performance work.