### PR TITLE
Faster Rival evaluation

### DIFF
--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -10,6 +10,7 @@
   (define args (rival-machine-arguments machine))
   (define ivec (rival-machine-instructions machine))
   (define rootvec (rival-machine-outputs machine))
+  (define slackvec (rival-machine-output-distance machine))
   (define discs (rival-machine-discs machine))
   (define vregs (rival-machine-registers machine))
   (define vrepeats (rival-machine-repeats machine))
@@ -19,20 +20,12 @@
   (define bumps (rival-machine-bumps machine))
 
   (define varc (vector-length args))
-  (define rootlen (vector-length rootvec))
   (define vprecs-new (make-vector (vector-length ivec) 0))          ; new vprecs vector
+
   ; Step 1. Adding slack in case of a rounding boundary issue
-  (for/vector #:length rootlen
-              ([root-reg (in-vector rootvec)] [disc (in-vector discs)]
-               #:when (>= root-reg varc))          ; when root is not a variable
-    (when (bigfloat? (ival-lo (vector-ref vregs root-reg)))         ; when root is a real op
-      (define result (vector-ref vregs root-reg))
-      (when
-          ; 1 ulp apart means double rounding issue possible
-          (= 1 ((discretization-distance disc)
-                ((discretization-convert disc) (ival-lo result))
-                ((discretization-convert disc) (ival-hi result))))
-        (vector-set! vprecs-new (- root-reg varc) (get-slack)))))
+  (for ([root-reg (in-vector rootvec)] [disc (in-vector discs)] [out-dr? (in-vector slackvec)]
+        #:when (>= root-reg varc) #:when out-dr?)
+    (vector-set! vprecs-new (- root-reg varc) (get-slack)))
 
   ; Step 2. Exponents calculation
   (exponents-propogation ivec vregs vprecs-new varc vstart-precs)

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -163,7 +163,7 @@
 
   (rival-machine
    (list->vector vars) instructions roots (list->vector discs)
-   registers repeats precisions initial-precisions
+   registers repeats precisions initial-precisions (make-vector (vector-length roots))
    0 0 0
    (make-vector (*rival-profile-executions*))
    (make-vector (*rival-profile-executions*))

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require racket/match (only-in math/private/bigfloat/mpfr bfprev bf bf-rounding-mode bf=?))
+(require racket/match (only-in math/private/bigfloat/mpfr bfprev bf bf-rounding-mode bf=?) racket/flonum)
 (require "../ops.rkt" "machine.rkt")
 (provide rival-compile)
 
@@ -167,7 +167,7 @@
    0 0 0
    (make-vector (*rival-profile-executions*))
    (make-vector (*rival-profile-executions*))
-   (make-vector (*rival-profile-executions*))
+   (make-flvector (*rival-profile-executions*))
    (make-vector (*rival-profile-executions*))))
 
 ; Function sets up vstart-precs vector, where all the precisions

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -13,7 +13,7 @@
 
 (struct rival-machine
   (arguments instructions outputs discs
-   registers repeats precisions initial-precisions
+   registers repeats precisions initial-precisions output-distance
    [iteration #:mutable] [bumps #:mutable]
    [profile-ptr #:mutable]
    profile-instruction profile-number profile-time profile-precision))

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -1,5 +1,6 @@
 #lang racket
 
+(require racket/flonum)
 (require "../ops.rkt" "machine.rkt" "compile.rkt" "run.rkt" "adjust.rkt")
 
 (provide rival-compile rival-apply rival-analyze
@@ -67,7 +68,7 @@
                      ([instruction (in-vector profile-instruction 0 profile-ptr)]
                       [number (in-vector profile-number 0 profile-ptr)]
                       [precision (in-vector profile-precision 0 profile-ptr)]
-                      [time (in-vector profile-time 0 profile-ptr)])
+                      [time (in-flvector profile-time 0 profile-ptr)])
            (execution instruction number precision time))
        (set-rival-machine-profile-ptr! machine 0))]))
 

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -25,30 +25,11 @@
   (rival-machine-adjust machine)
   (rival-machine-load machine inputs)
   (rival-machine-run machine)
-  (define outvec (rival-machine-return machine))
-  (define outlen (vector-length outvec))
-  (define discs (rival-machine-discs machine))
-  (for/vector #:length outlen ([y (in-vector outvec)] [disc (in-vector discs)])
-    (ival-then
-     ; The two `invalid` ones have to go first, because later checks
-     ; can error if the input is erroneous
-     (ival-assert (ival-not (ival-error? y)) 'invalid)
-     ; 'infinte case handle in `ival-eval`
-     (ival-assert
-      (if (ground-truth-require-convergence)
-          (is-samplable-interval disc y)
-          (ival (ival-hi (is-samplable-interval disc y))))
-      'unsamplable)
-     y)))
+  (rival-machine-return machine))
 
 (struct exn:rival exn:fail ())
 (struct exn:rival:invalid exn:rival (pt))
 (struct exn:rival:unsamplable exn:rival (pt))
-
-(define (ival-any-error? ivals)
-  (for/fold ([out (ival-error? (vector-ref ivals 0))])
-            ([iv (in-vector ivals 1)])
-    (ival-or out (ival-error? iv))))
 
 (struct execution (name number precision time) #:prefab)
 
@@ -79,26 +60,24 @@
   (define discs (rival-machine-discs machine))
   (set-rival-machine-bumps! machine 0)
   (let loop ([iter 0])
-    (define exs
+    (define-values (good? bad? stuck? fvec)
       (parameterize ([*sampling-iteration* iter]
                      [ground-truth-require-convergence #t])
         (rival-machine-full machine (vector-map ival-real pt))))
-    (match-define (ival err err?) (ival-any-error? exs))
     (cond
-      [err
+      [good? fvec]
+      [bad?
        (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
-      [(not err?)
-       (for/vector #:length (vector-length discs) ([ex (in-vector exs)] [disc (in-vector discs)])
-         ; We are promised at this point that (distance (convert lo) (convert hi)) = 0 so use lo
-         ([discretization-convert disc] (ival-lo ex)))]
+      [stuck?
+       (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [(>= iter (*rival-max-iterations*))
        (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [else
        (loop (+ 1 iter))])))
 
 (define (rival-analyze machine rect)
-  (define res
+  (define-values (good? bad? stuck? fvec)
     (parameterize ([*sampling-iteration* 0]
                    [ground-truth-require-convergence #f])
       (rival-machine-full machine rect)))
-  (ival-any-error? res))
+  (ival (not good?) (or bad? stuck?)))

--- a/eval/run.rkt
+++ b/eval/run.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
-(require (only-in math/private/bigfloat/mpfr bf-precision) racket/match racket/function)
 (require "machine.rkt" "adjust.rkt")
+(require (only-in math/private/bigfloat/mpfr bf-precision) racket/match racket/function racket/flonum)
 (provide rival-machine-load rival-machine-run rival-machine-return rival-machine-adjust)
 
 (define (rival-machine-load machine args)
@@ -18,7 +18,7 @@
     (vector-set! profile-instruction profile-ptr name)
     (vector-set! profile-number profile-ptr number)
     (vector-set! profile-precision profile-ptr precision)
-    (vector-set! profile-time profile-ptr time)
+    (flvector-set! profile-time profile-ptr time)
     (set-rival-machine-profile-ptr! machine (add1 profile-ptr))))
 
 (define (rival-machine-run machine)

--- a/eval/run.rkt
+++ b/eval/run.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 
-(require (only-in math/private/bigfloat/mpfr bf-precision) racket/match racket/function racket/flonum)
-(require "machine.rkt" "adjust.rkt" "../ops.rkt")
+(require racket/match racket/function racket/flonum)
+(require "machine.rkt" "adjust.rkt" "../mpfr.rkt" "../ops/all.rkt")
 (provide rival-machine-load rival-machine-run rival-machine-return rival-machine-adjust)
 
 (define (rival-machine-load machine args)


### PR DESCRIPTION
This PR speeds up Rival evaluation with two tweaks:
- Use an flvector for timing information, which should avoid some boxing
- Convert to float once and store slack information for later instead of recomputing it