### PR TITLE
Split `pow` into its own file

### DIFF
--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -2,7 +2,7 @@
 
 (require racket/function racket/list racket/match)
 (require (only-in math/private/bigfloat/mpfr bigfloat? mpfr-exp mpfr-sign bfnegative?))
-(require "../ops.rkt" "machine.rkt")
+(require "../ops/all.rkt" "machine.rkt")
 (provide backward-pass)
 
 (define (backward-pass machine)

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require racket/match (only-in math/private/bigfloat/mpfr bfprev bf bf-rounding-mode bf=?))
-(require "../ops.rkt" "machine.rkt")
+(require "../ops/all.rkt" "machine.rkt")
 (provide rival-compile)
 
 (define (optimize expr)

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -1,6 +1,5 @@
 #lang racket/base
 
-(require "../ops.rkt")
 (provide (struct-out discretization) (struct-out rival-machine)
          *rival-max-precision* *rival-max-iterations* *rival-profile-executions*
          *ampl-tuning-bits* *sampling-iteration* *base-tuning-precision*)

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "../ops.rkt" "machine.rkt" "compile.rkt" "run.rkt" "adjust.rkt")
+(require "../ops/all.rkt" "machine.rkt" "compile.rkt" "run.rkt" "adjust.rkt")
 
 (provide rival-compile rival-apply rival-analyze
          (struct-out exn:rival)

--- a/main.rkt
+++ b/main.rkt
@@ -3,7 +3,7 @@
 (require math/bigfloat racket/contract)
 (define value? (or/c bigfloat? boolean?))
 
-(require "ops.rkt")
+(require "ops/all.rkt")
 (define ival-list? (listof ival?))
 
 (provide ival? ival

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -31,5 +31,17 @@
   (values out exact?))
 ;; End hairy code
 
-(provide bf bigfloat? bf=? bfnan? bfinfinite? pi.bf bfexp bflte? bfgte? mpfr-sign bfzero? bfmin2 bfmax2 bfadd bfsub bfmul bfdiv bflt? bfgt? bfgte? bfneg bigfloat-exponent bfrint bfround bfceiling bffloor bftruncate bfabs bigfloat-precision bf-precision bflog bfprev bfnext bfexp bfexp2 bfexpm1 bflog2 bflog1p bflog10 bfsqrt bfcbrt bfexpt bfhypot bfcos bfeven? bfodd? bfsin bftan bfcos bfsinh bfcosh bftanh bfasin bfacos bfatan bfatan2 bfasinh bfacosh bfatanh bfstep bigfloats-between bflog-gamma bfpositive? bfinteger? bferf bferfc bfcopy mpfr-exp)
+(provide
+ bf bigfloat? mpfr-sign bigfloat-exponent bigfloat-precision bf-precision mpfr-exp
+ bfpositive? bfinteger? bfzero? bfnan? bfinfinite? bfeven? bfodd? 
+ bfcopy bfstep bigfloats-between bfprev bfnext 
+ bf=? bflte? bfgte? bflt? bfgt? bfgte? 
+ pi.bf bfmin2 bfmax2
+ bfabs bfadd bfsub bfneg bfmul bfdiv
+ bfrint bfround bfceiling bffloor bftruncate
+ bfexp bflog bfexp2 bfexpm1 bflog2 bflog1p bflog10 bfexpt 
+ bfsqrt bfcbrt bfhypot 
+ bfsin bfcos bftan bfsinh bfcosh bftanh
+ bfasin bfacos bfatan bfatan2 bfasinh bfacosh bfatanh
+ bflog-gamma bferf bferfc)
 

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -1,3 +1,35 @@
 #lang racket/base
 
-(require math/private/bigfloat/mpfr)
+(require math/private/bigfloat/mpfr ffi/unsafe)
+
+(provide -inf.bf -1.bf 0.bf half.bf 1.bf 2.bf 3.bf +inf.bf +nan.bf
+         bf-return-exact? rnd)
+
+(define-syntax-rule (rnd mode op args ...)
+  (parameterize ([bf-rounding-mode mode])
+    (op args ...)))
+
+(define -inf.bf (bf -inf.0))
+(define -1.bf (bf -1))
+(define 0.bf (bf 0))
+(define half.bf (bf 0.5))
+(define 1.bf (bf 1))
+(define 2.bf (bf 2))
+(define 3.bf (bf 3))
+(define +inf.bf (bf +inf.0))
+(define +nan.bf (bf +nan.0))
+
+;; Some hairy code follows to access the MPFR "inexact" exception.
+;; It assumes no one else cares about the flag, so it clobbers it.
+(define mpfr_clear_inexflag (get-mpfr-fun 'mpfr_clear_inexflag (_fun -> _void)))
+(define mpfr_get_inexflag (get-mpfr-fun 'mpfr_inexflag_p (_fun -> _int)))
+
+(define (bf-return-exact? op args)
+  (mpfr_clear_inexflag)
+  (define out (apply op args))
+  (define exact? (= (mpfr_get_inexflag) 0))
+  (values out exact?))
+;; End hairy code
+
+(provide bf bigfloat? bf=? bfnan? bfinfinite? pi.bf bfexp bflte? bfgte? mpfr-sign bfzero? bfmin2 bfmax2 bfadd bfsub bfmul bfdiv bflt? bfgt? bfgte? bfneg bigfloat-exponent bfrint bfround bfceiling bffloor bftruncate bfabs bigfloat-precision bf-precision bflog bfprev bfnext bfexp bfexp2 bfexpm1 bflog2 bflog1p bflog10 bfsqrt bfcbrt bfexpt bfhypot bfcos bfeven? bfodd? bfsin bftan bfcos bfsinh bfcosh bftanh bfasin bfacos bfatan bfatan2 bfasinh bfacosh bfatanh bfstep bigfloats-between bflog-gamma bfpositive? bfinteger? bferf bferfc bfcopy mpfr-exp)
+

--- a/ops/all.rkt
+++ b/ops/all.rkt
@@ -1,0 +1,20 @@
+#lang racket
+
+(require "core.rkt" "pow.rkt")
+
+(provide
+ ival? (rename-out [ival-expander ival] [ival-hi-val ival-hi] [ival-lo-val ival-lo])
+ ival-union ival-split monotonic->ival comonotonic->ival
+ ival-illegal ival-pi ival-e ival-bool
+ ival-add ival-sub ival-neg ival-mult ival-div ival-fma       
+ ival-fabs ival-sqrt ival-cbrt ival-hypot ival-exp ival-exp2 ival-expm1
+ ival-log ival-log2 ival-log10 ival-log1p ival-logb ival-pow ival-pow2
+ ival-sin ival-cos ival-tan
+ ival-asin ival-acos ival-atan ival-atan2 ival-sinh ival-cosh ival-tanh
+ ival-asinh ival-acosh ival-atanh ival-erf ival-erfc ival-lgamma ival-tgamma    
+ ival-fmod ival-remainder ival-rint ival-round ival-ceil ival-floor ival-trunc     
+ ival-fmin ival-fmax ival-copysign ival-fdim ival-sort      
+ ival-< ival-<= ival-> ival->= ival-== ival-!= ival-if ival-and ival-or ival-not       
+ ival-error? ival-assert ival-then close-enough->ival
+ ;; Deprecated
+ ival-lo-fixed? ival-hi-fixed? ival-err? ival-err mk-ival)

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -5,6 +5,7 @@
 
 (provide ival-lo-val ival-hi-val classify-ival rnd
          ival-exact-fabs ival-maybe
+         1.bf 2.bf 0.bf -1.bf 3.bf +nan.bf +inf.bf -inf.bf half.bf
          bf-return-exact? ival-lo-fixed? ival-hi-fixed?
          overflows-loose-at exp2-overflow-threshold)
 

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -303,7 +303,7 @@
   (match-define (ival (endpoint ylo ylo!) (endpoint yhi yhi!) yerr? yerr) y)
   (ival (endpoint ylo (or ylo! (bflte? xhi lo) (and (bflte? xlo lo) xlo!)))
         (endpoint yhi (or yhi! (bflte? xhi lo) (bfgte? xlo hi) (and (bfgte? xhi hi) xhi!)))
-        xerr? xerr))
+        yerr? yerr))
 
 (define* ival-neg (comonotonic bfneg))
 

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -3,13 +3,18 @@
 (require racket/contract racket/match racket/function math/private/bigfloat/mpfr racket/list)
 (require (for-syntax racket/base))
 
+(provide ival-lo-val ival-hi-val classify-ival rnd
+         ival-exact-fabs ival-maybe
+         bf-return-exact? ival-lo-fixed? ival-hi-fixed?
+         overflows-loose-at exp2-overflow-threshold)
+
 (provide
- ival? (rename-out [ival-expander ival] [ival-hi-val ival-hi] [ival-lo-val ival-lo])
+ (struct-out ival) (struct-out endpoint) ival-expander
  ival-union ival-split (rename-out [monotonic monotonic->ival] [comonotonic comonotonic->ival])
  ival-illegal ival-pi ival-e ival-bool
  ival-add ival-sub ival-neg ival-mult ival-div ival-fma       
  ival-fabs ival-sqrt ival-cbrt ival-hypot ival-exp ival-exp2 ival-expm1
- ival-log ival-log2 ival-log10 ival-log1p ival-logb ival-pow ival-pow2
+ ival-log ival-log2 ival-log10 ival-log1p ival-logb
  ival-sin ival-cos ival-tan       
  ival-asin ival-acos ival-atan ival-atan2 ival-sinh ival-cosh ival-tanh
  ival-asinh ival-acosh ival-atanh ival-erf ival-erfc ival-lgamma ival-tgamma    
@@ -118,13 +123,6 @@
   (cond
     [(or (= (mpfr-sign (ival-lo-val x)) 1) (bfzero? (ival-lo-val x))) 1]
     [(or (= (mpfr-sign (ival-hi-val x)) -1) (bfzero? (ival-hi-val x))) -1]
-    [else 0]))
-
-(define (classify-pos-ival-1 x) ;; Assumes x positive
-  (define x.lo (ival-lo-val x))
-  (cond
-    [(>= (mpfr-exp (ival-lo-val x)) 1) 1]
-    [(< (mpfr-exp (ival-hi-val x)) 1) -1]
     [else 0]))
 
 (define (classify-ival-strict x)
@@ -402,84 +400,6 @@
   (define y* (ival-exact-fabs y))
   (ival (rnd 'down eplinear bfhypot (ival-lo x*) (ival-lo y*))
         (rnd 'up   eplinear bfhypot (ival-hi x*) (ival-hi y*)) err? err))
-
-(define (eppow a-endpoint b-endpoint a-class b-class)
-  (match-define (endpoint a a!) a-endpoint)
-  (match-define (endpoint b b!) b-endpoint)
-  (define-values (val exact?) (bf-return-exact? bfexpt (list a b)))
-  (endpoint val
-   (or (and a! b! exact?)
-       (and a! (bf=? a 1.bf))
-       (and a! (bfzero? a) (not (= b-class 0)))
-       (and a! (bfinfinite? a) (not (= b-class 0)))
-       (and b! (bfzero? b))
-       (and b! (bfinfinite? b) (not (= a-class 0))))))
-
-(define (ival-copy-movability i1 i2)
-  (ival (endpoint (ival-lo-val i1) (ival-lo-fixed? i2))
-        (endpoint (ival-hi-val i1) (ival-hi-fixed? i2))
-        (ival-err? i1)
-        (ival-err i1)))
-
-(define (ival-pow-pos x y)
-  ;; Assumes x is positive; code copied from ival-mult
-  (match-define (ival xlo xhi xerr? xerr) x)
-  (match-define (ival ylo yhi yerr? yerr) y)
-  (define x-class (classify-pos-ival-1 x))
-  (define y-class (classify-ival y))
-
-  (define (mk-pow a b c d)
-    (match-define (endpoint lo lo!) (rnd 'down eppow a b x-class y-class))
-    (match-define (endpoint hi hi!) (rnd 'up   eppow c d x-class y-class))
-    (define out
-      (ival (endpoint lo lo!) (endpoint hi hi!)
-            (or xerr? yerr? (and (bfzero? (endpoint-val xlo)) (not (= y-class 1))))
-            (or xerr yerr (and (bfzero? (endpoint-val xhi)) (= y-class -1)))))
-    (if (or (bfzero? lo) (bfinfinite? lo) (bfzero? hi) (bfinfinite? hi))
-        ((overflows-loose-at (bfneg exp2-overflow-threshold) exp2-overflow-threshold)
-         (ival-mult y (ival-log2 x)) out)
-        out))
-
-  (match* (x-class y-class)
-    [( 1  1) (mk-pow xlo ylo xhi yhi)]
-    [( 1  0) (mk-pow xhi ylo xhi yhi)]
-    [( 1 -1) (mk-pow xhi ylo xlo yhi)]
-    [( 0  1) (mk-pow xlo yhi xhi yhi)]
-    [( 0 -1) (mk-pow xhi ylo xlo ylo)]
-    [(-1  1) (mk-pow xlo yhi xhi ylo)]
-    [(-1  0) (mk-pow xlo yhi xlo ylo)]
-    [(-1 -1) (mk-pow xhi yhi xlo ylo)]
-    [( 0  0) ;; Special case
-     (ival-union (mk-pow xlo yhi xhi yhi) (mk-pow xhi ylo xlo ylo))]))
-
-
-(define (ival-pow-neg x y)
-  ;; Assumes x is negative
-  (if (bf=? (ival-lo-val y) (ival-hi-val y))
-      (if (bfinteger? (ival-lo-val y))
-          ; If y is an integer point interval, there's no error,
-          ; because it's always valid to raise to an integer power.
-          (if (bfodd? (ival-lo-val y))
-              (ival-neg (ival-pow-pos (ival-exact-fabs x) y)) ; Use fabs in case of [x, 0]
-              (ival-pow-pos (ival-exact-fabs x) y))
-          ; If y is non-integer point interval, it must be an even
-          ; fraction (because all bigfloats are) so we always error
-          ival-illegal)
-      ; Moreover, if we have (-x)^y, that's basically x^y U -(x^y).
-      (let ([pospow (ival-pow-pos (ival-exact-fabs x) y)])
-        (ival-then (ival-assert ival-maybe) (ival-union (ival-neg pospow) pospow)))))
-
-(define* ival-pow2 (compose (monotonic (lambda (x) (bfmul x x))) ival-exact-fabs))
-
-(define (ival-pow x y)
-  (cond
-   [(and (bf=? (ival-hi-val y) 2.bf) (bf=? (ival-lo-val y) 2.bf))
-    (ival-pow2 x)]
-   [(and (= (mpfr-sign (ival-hi-val x)) -1) (not (bfzero? (ival-hi-val x)))) (ival-pow-neg x y)]
-   [(or (= (mpfr-sign (ival-lo-val x)) 1) (bfzero? (ival-hi-val x))) (ival-pow-pos x y)]
-   [else
-    (define-values (neg pos) (split-ival x 0.bf))
-    (ival-union (ival-pow-neg neg y) (ival-pow-pos pos y))]))
 
 (define (ival-fma a b c)
   (ival-add (ival-mult a b) c))

--- a/ops/pow.rkt
+++ b/ops/pow.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "core.rkt" math/private/bigfloat/mpfr)
+(require "core.rkt" (except-in math/private/bigfloat/mpfr -inf.bf 3.bf +inf.bf 0.bf 1.bf 2.bf +nan.bf -1.bf))
 (provide ival-pow ival-pow2)
 
 (define (classify-pos-ival-1 x) ;; Assumes x positive
@@ -80,11 +80,9 @@
   ((monotonic->ival (lambda (x) (bfmul x x))) (ival-exact-fabs x)))
 
 (define (ival-pow x y)
-  (cond
-   [(and (bf=? (ival-hi-val y) 2.bf) (bf=? (ival-lo-val y) 2.bf))
-    (ival-pow2 x)]
-   [(and (= (mpfr-sign (ival-hi-val x)) -1) (not (bfzero? (ival-hi-val x)))) (ival-pow-neg x y)]
-   [(or (= (mpfr-sign (ival-lo-val x)) 1) (bfzero? (ival-hi-val x))) (ival-pow-pos x y)]
-   [else
+  (match (classify-ival x)
+   [-1 (ival-pow-neg x y)]
+   [1 (ival-pow-pos x y)]
+   [0
     (define-values (neg pos) (ival-split x 0.bf))
     (ival-union (ival-pow-neg neg y) (ival-pow-pos pos y))]))

--- a/ops/pow.rkt
+++ b/ops/pow.rkt
@@ -1,0 +1,90 @@
+#lang racket
+
+(require "core.rkt" math/private/bigfloat/mpfr)
+(provide ival-pow ival-pow2)
+
+(define (classify-pos-ival-1 x) ;; Assumes x positive
+  (define x.lo (ival-lo-val x))
+  (cond
+    [(>= (mpfr-exp (ival-lo-val x)) 1) 1]
+    [(< (mpfr-exp (ival-hi-val x)) 1) -1]
+    [else 0]))
+
+(define (eppow a-endpoint b-endpoint a-class b-class)
+  (match-define (endpoint a a!) a-endpoint)
+  (match-define (endpoint b b!) b-endpoint)
+  (define-values (val exact?) (bf-return-exact? bfexpt (list a b)))
+  (endpoint val
+   (or (and a! b! exact?)
+       (and a! (bf=? a 1.bf))
+       (and a! (bfzero? a) (not (= b-class 0)))
+       (and a! (bfinfinite? a) (not (= b-class 0)))
+       (and b! (bfzero? b))
+       (and b! (bfinfinite? b) (not (= a-class 0))))))
+
+(define (ival-copy-movability i1 i2)
+  (ival (endpoint (ival-lo-val i1) (ival-lo-fixed? i2))
+        (endpoint (ival-hi-val i1) (ival-hi-fixed? i2))
+        (ival-err? i1)
+        (ival-err i1)))
+
+(define (ival-pow-pos x y)
+  ;; Assumes x is positive; code copied from ival-mult
+  (match-define (ival xlo xhi xerr? xerr) x)
+  (match-define (ival ylo yhi yerr? yerr) y)
+  (define x-class (classify-pos-ival-1 x))
+  (define y-class (classify-ival y))
+
+  (define (mk-pow a b c d)
+    (match-define (endpoint lo lo!) (rnd 'down eppow a b x-class y-class))
+    (match-define (endpoint hi hi!) (rnd 'up   eppow c d x-class y-class))
+    (define out
+      (ival (endpoint lo lo!) (endpoint hi hi!)
+            (or xerr? yerr? (and (bfzero? (endpoint-val xlo)) (not (= y-class 1))))
+            (or xerr yerr (and (bfzero? (endpoint-val xhi)) (= y-class -1)))))
+    (if (or (bfzero? lo) (bfinfinite? lo) (bfzero? hi) (bfinfinite? hi))
+        ((overflows-loose-at (bfneg exp2-overflow-threshold) exp2-overflow-threshold)
+         (ival-mult y (ival-log2 x)) out)
+        out))
+
+  (match* (x-class y-class)
+    [( 1  1) (mk-pow xlo ylo xhi yhi)]
+    [( 1  0) (mk-pow xhi ylo xhi yhi)]
+    [( 1 -1) (mk-pow xhi ylo xlo yhi)]
+    [( 0  1) (mk-pow xlo yhi xhi yhi)]
+    [( 0 -1) (mk-pow xhi ylo xlo ylo)]
+    [(-1  1) (mk-pow xlo yhi xhi ylo)]
+    [(-1  0) (mk-pow xlo yhi xlo ylo)]
+    [(-1 -1) (mk-pow xhi yhi xlo ylo)]
+    [( 0  0) ;; Special case
+     (ival-union (mk-pow xlo yhi xhi yhi) (mk-pow xhi ylo xlo ylo))]))
+
+
+(define (ival-pow-neg x y)
+  ;; Assumes x is negative
+  (if (bf=? (ival-lo-val y) (ival-hi-val y))
+      (if (bfinteger? (ival-lo-val y))
+          ; If y is an integer point interval, there's no error,
+          ; because it's always valid to raise to an integer power.
+          (if (bfodd? (ival-lo-val y))
+              (ival-neg (ival-pow-pos (ival-exact-fabs x) y)) ; Use fabs in case of [x, 0]
+              (ival-pow-pos (ival-exact-fabs x) y))
+          ; If y is non-integer point interval, it must be an even
+          ; fraction (because all bigfloats are) so we always error
+          ival-illegal)
+      ; Moreover, if we have (-x)^y, that's basically x^y U -(x^y).
+      (let ([pospow (ival-pow-pos (ival-exact-fabs x) y)])
+        (ival-then (ival-assert ival-maybe) (ival-union (ival-neg pospow) pospow)))))
+
+(define (ival-pow2 x)
+  ((monotonic->ival (lambda (x) (bfmul x x))) (ival-exact-fabs x)))
+
+(define (ival-pow x y)
+  (cond
+   [(and (bf=? (ival-hi-val y) 2.bf) (bf=? (ival-lo-val y) 2.bf))
+    (ival-pow2 x)]
+   [(and (= (mpfr-sign (ival-hi-val x)) -1) (not (bfzero? (ival-hi-val x)))) (ival-pow-neg x y)]
+   [(or (= (mpfr-sign (ival-lo-val x)) 1) (bfzero? (ival-hi-val x))) (ival-pow-pos x y)]
+   [else
+    (define-values (neg pos) (ival-split x 0.bf))
+    (ival-union (ival-pow-neg neg y) (ival-pow-pos pos y))]))

--- a/ops/pow.rkt
+++ b/ops/pow.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "core.rkt" (except-in math/private/bigfloat/mpfr -inf.bf 3.bf +inf.bf 0.bf 1.bf 2.bf +nan.bf -1.bf))
+(require "core.rkt" "../mpfr.rkt")
 (provide ival-pow ival-pow2)
 
 (define (classify-pos-ival-1 x) ;; Assumes x positive


### PR DESCRIPTION
This PR adds a bunch of new files:

- `mpfr.rkt` is now our central MPFR interface, a dumping ground for weird MPFR functions used elsewhere
- `ops/core.rkt` is the old `ops.rkt`, but with at least some stuff moved out. Eventually the goal is to move out everything
- `ops/pow.rkt` shows that at least `pow` can be moved out

It also fixes a bug in `pow` introduced in #41.