### PR TITLE
Safe sampling feature fix

### DIFF
--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -56,7 +56,8 @@
           [n (in-range (vector-length vprecs))])
       (define prec* (min (*rival-max-precision*) (+ prec slack)))
       (when (equal? prec* (*rival-max-precision*)) (*sampling-iteration* (*rival-max-iterations*)))
-      (vector-set! vprecs n prec*))))
+      (vector-set! vprecs n prec*))
+    (vector-fill! vrepeats #f)))
 
 ; This function goes through ivec and vregs and calculates (+ exponents base-precisions) for each operator in ivec
 ; Roughly speaking:


### PR DESCRIPTION
I believe that this bug was introduced with safe-sampling-feature by itself.
The problem is: we increase everything with slack hoping that the new results will be better,
However the machine skips all the evaluation because `vrepeats` vector was pitched previously with `#t` for all the instructions