### PR TITLE
Add "explain" mode to Rival repl

### DIFF
--- a/eval/repl.rkt
+++ b/eval/repl.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require racket/match racket/string)
+(require racket/match racket/string racket/format)
 (require (only-in math/private/bigfloat/mpfr bfcopy bigfloats-between bf-precision bigfloat->string bf))
 (require "main.rkt" "machine.rkt")
 (provide rival-repl)
@@ -16,6 +16,11 @@
     [`E '(E)]
     [`(,op ,args ...) (list* op (map fix-up-fpcore args))]
     [_ expr]))
+
+(define (normalize-function-name name)
+  (if (string-prefix? name "ival-")
+      (substring name 5)
+      name))
 
 (define (rival-repl)
   (parameterize ([read-decimal-as-inexact #f])
@@ -33,6 +38,56 @@
          (hash-set! fns name
                     (rival-compile (list (fix-up-fpcore body)) args
                                    (list (bf-discretization precision))))]
+        [`(explain ,(? symbol? name) ,(? real? vals) ...)
+         (define machine (hash-ref fns name))
+         (unless (= (vector-length (rival-machine-arguments machine)) (length vals))
+           (define args (rival-machine-arguments machine))
+           (raise-user-error name "Expects ~a arguments: ~a"
+                             (length args) (string-join " " (map symbol->string args))))
+         (rival-profile machine 'executions)
+         (define start (current-inexact-milliseconds))
+         (parameterize ([bf-precision precision])
+           (vector-ref (rival-apply machine (list->vector (map bf vals))) 0))
+         (define end (current-inexact-milliseconds))
+         (define execs (rival-profile machine 'executions))
+         (define num-instructions (rival-profile machine 'instructions))
+         (define num-iterations (rival-profile machine 'iterations))
+         (define num-args (vector-length (rival-machine-arguments machine)))
+         (printf "Executed ~a instructions for ~a iterations:\n\n" num-instructions num-iterations)
+
+         (define names (make-vector (+ num-instructions 1) #f))
+         (define iters (make-vector (+ num-instructions 1) 0))
+         (define times (build-vector (+ num-instructions 1) (lambda (i) (make-hash))))
+         (define precs (build-vector num-instructions (lambda (i) (make-hash))))
+
+         (for ([exec (in-vector execs)])
+           (match-define (execution name number precision time) exec)
+           (define number* (if (eq? name 'adjust) num-instructions (- number num-args)))
+           (vector-set! names number* name)
+           (define iter (vector-ref iters number*))
+           (hash-set! (vector-ref times number*) iter time)
+           (when (< number* num-instructions)
+             (hash-set! (vector-ref precs number*) iter precision))
+           (vector-set! iters number* (+ iter 1)))
+
+         (for ([name (in-vector names)] [iters (in-vector iters)]
+                                        [time-n (in-vector times)] [prec-n (in-vector precs)])
+           (display (~a (normalize-function-name (~a name)) #:width 8))
+           (for ([n (in-range iters)])
+             (when (and (hash-has-key? time-n n) (hash-has-key? prec-n n))
+               (display (~r (hash-ref prec-n n) #:min-width 8)))
+               (display (~r (* (hash-ref time-n n) 1000) #:precision '(= 2) #:min-width 8)))
+           (newline))
+
+         (display "adjust  ")
+         (define time-n (vector-ref times num-instructions))
+         (display "        ")
+         (display "        ")
+         (for ([i (in-range (vector-ref iters num-instructions))])
+           (display "        ")
+           (display (~r (* (hash-ref time-n i) 1000) #:precision '(= 2) #:min-width 8)))
+
+         (printf "\n\nTotal: ~ams\n" (~r (- end start) #:precision '(= 3)))]
         [`(eval ,body)
          (define machine (rival-compile (list (fix-up-fpcore body)) '()
                                         (list (bf-discretization precision))))


### PR DESCRIPTION
This PR adds a command, `(explain f args ...)`, to the Rival repo. This generates an ASCII table showing the precision and time for executing each command at each iteration:

```
> (define (cos2 x e) (- (cos x) (cos (+ x e))))
> (explain cos2 1e300 1e-300)
Executed 4 instructions for 2 iterations:

cos           78  349.85     592  205.08    1695  191.16
add           83   23.93    2107   10.99    2698   10.99
cos           78   10.99     593  188.96    1695  283.94
sub           73   19.04      73   10.99      73   10.99
adjust                             50.05           22.95

Total: 1.922ms
> exit
```

Honestly, some of the numbers are kind-of hard to believe (why does `add` get faster at higher precision? Same for `cos`) but that can presumably be fixed later, as can some more labels for the plot and so on.