### PR TITLE
Make the explain output nicer

### DIFF
--- a/eval/repl.rkt
+++ b/eval/repl.rkt
@@ -22,6 +22,32 @@
       (substring name 5)
       name))
 
+(define (executions-iterations execs)
+  (define iter 0)
+  (define last #f)
+  (for/list ([exec (in-vector execs)])
+    (match-define (execution name id precision time) exec)
+    (when (and last (< id last))
+      (set! iter (+ iter 1)))
+    (set! last id)
+    (cons iter exec)))
+
+(define (write-table fn #:rows rows #:cols cols #:width [width 8])
+  (for ([row (in-range rows)])
+    (for ([col (in-range cols)])
+      (display (~a (fn row col) #:width width #:align 'right)))
+    (newline)))
+
+(define-syntax-rule (list-find-match l pattern body ...)
+  (let loop ([l l])
+    (match l
+      [(cons pattern rest)
+       body ...]
+      [(cons _ rest)
+       (loop rest)]
+      ['()
+       ""])))
+
 (define (rival-repl)
   (parameterize ([read-decimal-as-inexact #f])
     (define fns (make-hash))
@@ -44,48 +70,66 @@
            (define args (rival-machine-arguments machine))
            (raise-user-error name "Expects ~a arguments: ~a"
                              (length args) (string-join " " (map symbol->string args))))
+         (define args
+           (parameterize ([bf-precision precision])
+             (list->vector (map bf vals))))
+
+         ;; Make sure the cache is warm
+         (rival-apply machine args)
+         ;; Make sure the profile is clear
          (rival-profile machine 'executions)
+
+         ;; Time the actual execution
          (define start (current-inexact-milliseconds))
-         (parameterize ([bf-precision precision])
-           (vector-ref (rival-apply machine (list->vector (map bf vals))) 0))
+         (rival-apply machine args)
          (define end (current-inexact-milliseconds))
+
          (define execs (rival-profile machine 'executions))
          (define num-instructions (rival-profile machine 'instructions))
-         (define num-iterations (rival-profile machine 'iterations))
+         (define num-iterations (+ 1 (rival-profile machine 'iterations)))
          (define num-args (vector-length (rival-machine-arguments machine)))
          (printf "Executed ~a instructions for ~a iterations:\n\n" num-instructions num-iterations)
 
-         (define names (make-vector (+ num-instructions 1) #f))
-         (define iters (make-vector (+ num-instructions 1) 0))
-         (define times (build-vector (+ num-instructions 1) (lambda (i) (make-hash))))
-         (define precs (build-vector num-instructions (lambda (i) (make-hash))))
-
-         (for ([exec (in-vector execs)])
-           (match-define (execution name number precision time) exec)
-           (define number* (if (eq? name 'adjust) num-instructions (- number num-args)))
-           (vector-set! names number* name)
-           (define iter (vector-ref iters number*))
-           (hash-set! (vector-ref times number*) iter time)
-           (when (< number* num-instructions)
-             (hash-set! (vector-ref precs number*) iter precision))
-           (vector-set! iters number* (+ iter 1)))
-
-         (for ([name (in-vector names)] [iters (in-vector iters)]
-                                        [time-n (in-vector times)] [prec-n (in-vector precs)])
-           (display (~a (normalize-function-name (~a name)) #:width 8))
-           (for ([n (in-range iters)])
-             (when (and (hash-has-key? time-n n) (hash-has-key? prec-n n))
-               (display (~r (hash-ref prec-n n) #:min-width 8)))
-               (display (~r (* (hash-ref time-n n) 1000) #:precision '(= 2) #:min-width 8)))
-           (newline))
-
-         (display "adjust  ")
-         (define time-n (vector-ref times num-instructions))
-         (display "        ")
-         (display "        ")
-         (for ([i (in-range (vector-ref iters num-instructions))])
-           (display "        ")
-           (display (~r (* (hash-ref time-n i) 1000) #:precision '(= 2) #:min-width 8)))
+         (define execs* (executions-iterations execs))
+         (write-table
+          #:rows (+ 5 num-instructions) ; 1 for the "adjust" row
+          #:cols (+ 1 (* 2 num-iterations))
+          #:width 6
+          (lambda (row col)
+            (match* (row col)
+              [(0 0) ""]
+              [(0 col) #:when (= (modulo col 2) 1) "Bits"]
+              [(0 col) #:when (= (modulo col 2) 0) "Time"]
+              [(1 _) "------"]
+              [(2 0) 'adjust]
+              [(2 col) #:when (and (= (modulo col 2) 0) (> col 2))
+               (define iter (- (/ col 2) 1))
+               (list-find-match execs* (cons (== iter) (execution 'adjust _ _ time))
+                 (~r (* time 1000) #:precision '(= 1)))]
+              [(2 col) ""]
+              [((== (+ 3 num-instructions)) _) "------"]
+              [((== (+ 4 num-instructions)) 0) "Total"]
+              [((== (+ 4 num-instructions)) col) #:when (= (modulo col 2) 1) ""]
+              [((== (+ 4 num-instructions)) col) #:when (= (modulo col 2) 0)
+               (define iter (/ (- col 2) 2))
+               (define time
+                 (apply + (for/list ([exec (in-list execs*)] #:when (= (car exec) iter))
+                            (execution-time (cdr exec)))))
+               (~r (* time 1000) #:precision '(= 1))]
+              [(row 0)
+               (define id (+ (- row 3) num-args))
+               (list-find-match execs* (cons _ (execution name (== id) _ _))
+                 (normalize-function-name (~a name)))]
+              [(row col) #:when (= (modulo col 2) 1) ; precision
+               (define id (+ (- row 3) num-args))
+               (define iter (/ (- col 1) 2))
+               (list-find-match execs* (cons (== iter) (execution _ (== id) prec _))
+                 prec)]
+              [(row col) #:when (= (modulo col 2) 0) ; time
+               (define id (+ (- row 3) num-args))
+               (define iter (/ (- col 2) 2))
+               (list-find-match execs* (cons (== iter) (execution _ (== id) _ time))
+                 (~r (* time 1000) #:precision '(= 1)))])))
 
          (printf "\n\nTotal: ~ams\n" (~r (- end start) #:precision '(= 3)))]
         [`(eval ,body)

--- a/eval/run.rkt
+++ b/eval/run.rkt
@@ -100,4 +100,4 @@
   (unless (zero? iter)
     (define start (current-inexact-milliseconds))
     (backward-pass machine)
-    (rival-machine-record machine 'adjust 0 (* iter 1000) (- (current-inexact-milliseconds) start))))
+    (rival-machine-record machine 'adjust -1 (* iter 1000) (- (current-inexact-milliseconds) start))))


### PR DESCRIPTION
This PR makes the `explain` output a little nicer. First, there's a table with totals:

```
> (define (cos2 x e) (- (cos x) (cos (+ x e))))
> (explain cos2 1e300 1e-300)
Executed 4 instructions for 3 iterations:

 Oper.  Bits  Time  Bits  Time  Bits  Time
------------------------------------------
adjust                    22.9        21.0
   cos    78  75.9   592  98.9  1695 173.1
   add    83  11.0  2107  10.0  2698  11.0
   cos    78   8.1   593  99.1  1695 176.0
   sub    73  10.0    73  10.0    73  11.0
------------------------------------------
 Total       105.0       241.0       392.1

Total: 0.857ms
```

Plus, I now apply once before profiling; this avoids cache issues and produces much nicer numbers, more representative of running several points through.