### PR TITLE
Fix `lgamma` for [-inf, +x]

### DIFF
--- a/ops/all.rkt
+++ b/ops/all.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require "core.rkt" "pow.rkt" "trig.rkt" "fmod.rkt")
+(require "core.rkt" "pow.rkt" "trig.rkt" "fmod.rkt" "gamma.rkt")
 
 (provide
  ival? (rename-out [ival-expander ival] [ival-hi-val ival-hi] [ival-lo-val ival-lo])

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -17,7 +17,7 @@
  ival-fabs ival-sqrt ival-cbrt ival-hypot ival-exp ival-exp2 ival-expm1
  ival-log ival-log2 ival-log10 ival-log1p ival-logb
  ival-asin ival-acos ival-atan ival-atan2 ival-sinh ival-cosh ival-tanh
- ival-asinh ival-acosh ival-atanh ival-erf ival-erfc ival-lgamma ival-tgamma    
+ ival-asinh ival-acosh ival-atanh ival-erf ival-erfc
  ival-rint ival-round ival-ceil ival-floor ival-trunc     
  ival-fmin ival-fmax ival-copysign ival-fdim ival-sort      
  ival-< ival-<= ival-> ival->= ival-== ival-!= ival-if ival-and ival-or ival-not       
@@ -427,140 +427,6 @@
 (define* ival-asinh (monotonic bfasinh))
 (define* ival-acosh (compose (monotonic bfacosh) (clamp 1.bf +inf.bf)))
 (define* ival-atanh (compose (monotonic bfatanh) (clamp-strict -1.bf 1.bf)))
-
-(define (bigfloat-midpoint lo hi)
-  (bfstep lo (inexact->exact (floor (/ (bigfloats-between lo hi) 2)))))
-
-(define (convex-find-min fn xlo xhi)
-  ; lgamma is always convex in the same direction
-  (let loop ([lo xlo] [mlo (bfdiv (bfadd (bfadd xlo xhi) xlo) 3.bf)]
-             [mhi (bfdiv (bfadd (bfadd xlo xhi) xhi) 3.bf)] [hi xhi])
-    (let ([ylo (rnd 'up fn lo)] [ymlo (rnd 'down fn mlo)]
-          [yhi (rnd 'up fn hi)] [ymhi (rnd 'down fn mhi)])
-      ;; Invariant: ylo >= ymlo and yhi >= ymhi.
-      ;; Base case: ylo and yhi = +inf.bf
-      ;; Therefore lgamma decreasing from lo to mlo and increasing from mhi to hi
-      (cond
-       [(<= (bigfloats-between lo hi) 3)
-        (define dy1 (rnd 'up bfsub ymlo ylo))
-        (define dy2 (rnd 'up bfsub ymhi yhi))
-        ; Overcorrect for possible deviation downward
-        (define dy (rnd 'up bfdiv (bfmax2 dy1 dy2) 2.bf))
-        (values mlo (rnd 'down bfadd ymlo dy))]
-       [(<= (bigfloats-between mlo mhi) 1) ; Close enough to exit
-        (loop (bfprev mlo) mlo mhi (bfnext mhi))]
-       [(bfgt? ymlo ymhi) ; If true, lgamma decreasing from mlo to mhi
-        (loop mlo mhi (bigfloat-midpoint mhi hi) hi)]
-       [else
-        (loop lo (bigfloat-midpoint lo mlo) mlo mhi)]))))
-
-;; These both assume that xmin and ymin are not immovable (they are computed with rounding)
-(define ((convex fn xmin ymin) i)
-  (match-define (ival lo hi err? err) i)
-  (cond
-   [(bfgt? (endpoint-val lo) xmin) ; Purely increasing
-    ((monotonic fn) i)]
-   [(bflt? (endpoint-val hi) xmin) ; Purely decreasing
-    ((comonotonic fn) i)]
-   [else
-    (ival-union
-     (ival (endpoint ymin #f) (rnd 'up epfn fn lo) err? err)
-     (ival (endpoint ymin #f) (rnd 'up epfn fn hi) err? err))]))
-
-; Optimized version of `ival-lgamma-basin` for positive values, adds a cache
-(define lgamma-pos-xmin #f)
-(define lgamma-pos-ymin #f)
-(define lgamma-pos-prec #f)
-
-(define (ival-lgamma-pos x)
-  (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-  (cond
-   [(bfgte? xlo (bf 1.5)) ; Fast path, gamma is increasing here
-    ((monotonic bflog-gamma) x)]
-   [(and (bfgte? xlo 0.bf) (bflte? xhi (bf 1.4))) ; Another fast path
-    ((comonotonic bflog-gamma) x)]
-   [else
-    ;; Gamma has a single minimum for positive inputs, which is about 1.46163
-    ;; This computation is common enough that we cache it
-    (unless (and lgamma-pos-prec (<= (bf-precision) lgamma-pos-prec))
-      (define-values (xmin ymin) (convex-find-min bflog-gamma (bf 1.46163) (bf 1.46164)))
-      (set! lgamma-pos-xmin xmin)
-      (set! lgamma-pos-ymin ymin)
-      (set! lgamma-pos-prec (bf-precision)))
-    ((convex bflog-gamma lgamma-pos-xmin lgamma-pos-ymin) x)]))
-
-;; Crude estimate, used only when other option is not available.
-;;  Note that G(-n + f) = +- G(f) G(1-f) / G(n + 1 - f).
-;; Thus, the min of G over [-n, -n + 1] is greater than
-;;   A) the min of G(f) G(1-f) over [0, 1]
-;;   B) divided by the max of G(n + 1 - f) over [0, 1]
-;; (A) is easy because that function is symmetric over [0, 1];
-;;   the min is at 1/2 with value G(1/2)^2 = pi
-;; (B) is also easy because G is increasing on [n, n + 1]
-;;   since n is positive, so the max is at n + 1
-;; Hence, G over [-n, -n + 1] is greater than
-;;   pi / G(n + 1);
-;; Hence, logG over [-n, -n + 1] is greater than
-;;   log pi - logG(n + 1)
-(define (ival-lgamma-basin-bound imin)
-  (define logpi (rnd 'down bflog (rnd 'down pi.bf)))
-  (define logg (rnd 'up bflog-gamma (rnd 'up bfadd 1.bf (bfneg imin))))
-  (define bound (rnd 'down bfsub logpi logg))
-  (ival (endpoint bound #f) (endpoint +inf.bf #f) #f #f))
-
-;; Here we assume that x is entirely negative
-;; and does not cross any integer boundaries.
-(define (ival-lgamma-basin x)
-  (define imin (bffloor (ival-lo-val x)))
-  (define imax (bfceiling (ival-hi-val x)))
-  (if (< (bigfloats-between imin imax) 25) ; Value 25 is not verified
-      (ival-then x (ival-lgamma-basin-bound imin)) ; Too close, cannot use convex
-      (let-values ([(xmin ymin) (convex-find-min bflog-gamma imin imax)])
-        ((convex bflog-gamma xmin ymin) x))))
-
-(define (ival-lgamma x)
-  ; The starred versions allow #f for an empty interval
-  (define (ival-lo-val* x) (if x (ival-lo-val x) 0.bf))
-  (define (ival-split* i x) (if i (ival-split i x) (values #f #f)))
-  (define (ival-union* a b) (if (and a b) (ival-union a b) (or a b)))
-
-  (define-values (xneg xpos) (ival-split x 0.bf))
-  (define-values (xnegl xrest) (ival-split* xneg (bfceiling (ival-lo-val* xneg))))
-  (define-values (xnegr xdrop) (ival-split* xrest (rnd 'up bfadd 1.bf (ival-lo-val* xrest))))
-
-  (if (or xpos xnegl xnegr)
-      (ival-union*
-       (and xpos (ival-lgamma-pos xpos))
-       (ival-union*
-        (and xnegl (ival-lgamma-basin xnegl))
-        (and xnegr (ival-lgamma-basin xnegr))))
-      ;; This case only happens if xnegr = #f meaning lo = rnd[up](lo + 1) meaning lo = -inf
-      (mk-big-ival -inf.bf +inf.bf)))
-
-(define (exact-bffloor x)
-  (parameterize ([bf-precision (bigfloat-precision x)])
-    (bffloor x)))
-
-(define (ival-tgamma x)
-  (define logy (ival-lgamma x))
-  (unless logy
-    (error 'ival-lgamma "Invalid input to ival-lgamma: ~a" x))
-  (define absy (ival-exp logy))
-  (define lo (ival-lo-val x))
-  (define hi (ival-hi-val x))
-  (cond
-   [(bfgte? lo 0.bf)
-    absy]
-   [(not (bf=? (exact-bffloor lo) (exact-bffloor hi)))
-    (ival (endpoint -inf.bf (ival-lo-fixed? x))
-          (endpoint +inf.bf (ival-hi-fixed? x))
-          #t (ival-err x))]
-   [(and (not (bfpositive? lo)) (bf=? lo hi) (bfinteger? lo))
-    ival-illegal]
-   [(bfeven? (exact-bffloor lo))
-    absy]
-   [else
-    (ival-neg absy)]))
 
 (define* ival-erf (monotonic bferf))
 (define* ival-erfc (comonotonic bferfc))

--- a/ops/gamma.rkt
+++ b/ops/gamma.rkt
@@ -104,14 +104,15 @@
   (define-values (xnegl xrest) (ival-split* xneg (bfceiling (ival-lo-val* xneg))))
   (define-values (xnegr xdrop) (ival-split* xrest (rnd 'up bfadd 1.bf (ival-lo-val* xrest))))
 
-  (if (or xpos xnegl xnegr)
-      (ival-union*
-       (and xpos (ival-lgamma-pos xpos))
-       (ival-union*
-        (and xnegl (ival-lgamma-basin xnegl))
-        (and xnegr (ival-lgamma-basin xnegr))))
-      ;; This case only happens if xnegr = #f meaning lo = rnd[up](lo + 1) meaning lo = -inf
-      (mk-big-ival -inf.bf +inf.bf)))
+  (define negy
+    (and xneg
+         (or (ival-union*
+              (and xnegl (ival-lgamma-basin xnegl))
+              (and xnegr (ival-lgamma-basin xnegr)))
+             ;; This case only happens if xnegr = #f meaning lo = rnd[up](lo + 1) meaning lo = -inf
+             (mk-big-ival -inf.bf +inf.bf))))
+             
+  (ival-union* (and xpos (ival-lgamma-pos xpos)) negy))
 
 (define (exact-bffloor x)
   (parameterize ([bf-precision (bigfloat-precision x)])

--- a/ops/gamma.rkt
+++ b/ops/gamma.rkt
@@ -1,0 +1,139 @@
+#lang racket/base
+
+(require racket/match)
+(require "core.rkt" "../mpfr.rkt")
+(provide ival-lgamma ival-tgamma)
+
+(define (bigfloat-midpoint lo hi)
+  (bfstep lo (inexact->exact (floor (/ (bigfloats-between lo hi) 2)))))
+
+(define (convex-find-min fn xlo xhi)
+  ; lgamma is always convex in the same direction
+  (let loop ([lo xlo] [mlo (bfdiv (bfadd (bfadd xlo xhi) xlo) 3.bf)]
+             [mhi (bfdiv (bfadd (bfadd xlo xhi) xhi) 3.bf)] [hi xhi])
+    (let ([ylo (rnd 'up fn lo)] [ymlo (rnd 'down fn mlo)]
+          [yhi (rnd 'up fn hi)] [ymhi (rnd 'down fn mhi)])
+      ;; Invariant: ylo >= ymlo and yhi >= ymhi.
+      ;; Base case: ylo and yhi = +inf.bf
+      ;; Therefore lgamma decreasing from lo to mlo and increasing from mhi to hi
+      (cond
+       [(<= (bigfloats-between lo hi) 3)
+        (define dy1 (rnd 'up bfsub ymlo ylo))
+        (define dy2 (rnd 'up bfsub ymhi yhi))
+        ; Overcorrect for possible deviation downward
+        (define dy (rnd 'up bfdiv (bfmax2 dy1 dy2) 2.bf))
+        (values mlo (rnd 'down bfadd ymlo dy))]
+       [(<= (bigfloats-between mlo mhi) 1) ; Close enough to exit
+        (loop (bfprev mlo) mlo mhi (bfnext mhi))]
+       [(bfgt? ymlo ymhi) ; If true, lgamma decreasing from mlo to mhi
+        (loop mlo mhi (bigfloat-midpoint mhi hi) hi)]
+       [else
+        (loop lo (bigfloat-midpoint lo mlo) mlo mhi)]))))
+
+;; These both assume that xmin and ymin are not immovable (they are computed with rounding)
+(define ((convex fn xmin ymin) i)
+  (match-define (ival lo hi err? err) i)
+  (cond
+   [(bfgt? (endpoint-val lo) xmin) ; Purely increasing
+    ((monotonic->ival fn) i)]
+   [(bflt? (endpoint-val hi) xmin) ; Purely decreasing
+    ((comonotonic->ival fn) i)]
+   [else
+    (ival-union
+     (ival (endpoint ymin #f) (rnd 'up epfn fn lo) err? err)
+     (ival (endpoint ymin #f) (rnd 'up epfn fn hi) err? err))]))
+
+; Optimized version of `ival-lgamma-basin` for positive values, adds a cache
+(define lgamma-pos-xmin #f)
+(define lgamma-pos-ymin #f)
+(define lgamma-pos-prec #f)
+
+(define (ival-lgamma-pos x)
+  (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
+  (cond
+   [(bfgte? xlo (bf 1.5)) ; Fast path, gamma is increasing here
+    ((monotonic->ival bflog-gamma) x)]
+   [(and (bfgte? xlo 0.bf) (bflte? xhi (bf 1.4))) ; Another fast path
+    ((comonotonic->ival bflog-gamma) x)]
+   [else
+    ;; Gamma has a single minimum for positive inputs, which is about 1.46163
+    ;; This computation is common enough that we cache it
+    (unless (and lgamma-pos-prec (<= (bf-precision) lgamma-pos-prec))
+      (define-values (xmin ymin) (convex-find-min bflog-gamma (bf 1.46163) (bf 1.46164)))
+      (set! lgamma-pos-xmin xmin)
+      (set! lgamma-pos-ymin ymin)
+      (set! lgamma-pos-prec (bf-precision)))
+    ((convex bflog-gamma lgamma-pos-xmin lgamma-pos-ymin) x)]))
+
+;; Crude estimate, used only when other option is not available.
+;;  Note that G(-n + f) = +- G(f) G(1-f) / G(n + 1 - f).
+;; Thus, the min of G over [-n, -n + 1] is greater than
+;;   A) the min of G(f) G(1-f) over [0, 1]
+;;   B) divided by the max of G(n + 1 - f) over [0, 1]
+;; (A) is easy because that function is symmetric over [0, 1];
+;;   the min is at 1/2 with value G(1/2)^2 = pi
+;; (B) is also easy because G is increasing on [n, n + 1]
+;;   since n is positive, so the max is at n + 1
+;; Hence, G over [-n, -n + 1] is greater than
+;;   pi / G(n + 1);
+;; Hence, logG over [-n, -n + 1] is greater than
+;;   log pi - logG(n + 1)
+(define (ival-lgamma-basin-bound imin)
+  (define logpi (rnd 'down bflog (rnd 'down pi.bf)))
+  (define logg (rnd 'up bflog-gamma (rnd 'up bfadd 1.bf (bfneg imin))))
+  (define bound (rnd 'down bfsub logpi logg))
+  (ival (endpoint bound #f) (endpoint +inf.bf #f) #f #f))
+
+;; Here we assume that x is entirely negative
+;; and does not cross any integer boundaries.
+(define (ival-lgamma-basin x)
+  (define imin (bffloor (ival-lo-val x)))
+  (define imax (bfceiling (ival-hi-val x)))
+  (if (< (bigfloats-between imin imax) 25) ; Value 25 is not verified
+      (ival-then x (ival-lgamma-basin-bound imin)) ; Too close, cannot use convex
+      (let-values ([(xmin ymin) (convex-find-min bflog-gamma imin imax)])
+        ((convex bflog-gamma xmin ymin) x))))
+
+(define (ival-lgamma x)
+  ; The starred versions allow #f for an empty interval
+  (define (ival-lo-val* x) (if x (ival-lo-val x) 0.bf))
+  (define (ival-split* i x) (if i (ival-split i x) (values #f #f)))
+  (define (ival-union* a b) (if (and a b) (ival-union a b) (or a b)))
+
+  (define-values (xneg xpos) (ival-split x 0.bf))
+  (define-values (xnegl xrest) (ival-split* xneg (bfceiling (ival-lo-val* xneg))))
+  (define-values (xnegr xdrop) (ival-split* xrest (rnd 'up bfadd 1.bf (ival-lo-val* xrest))))
+
+  (if (or xpos xnegl xnegr)
+      (ival-union*
+       (and xpos (ival-lgamma-pos xpos))
+       (ival-union*
+        (and xnegl (ival-lgamma-basin xnegl))
+        (and xnegr (ival-lgamma-basin xnegr))))
+      ;; This case only happens if xnegr = #f meaning lo = rnd[up](lo + 1) meaning lo = -inf
+      (mk-big-ival -inf.bf +inf.bf)))
+
+(define (exact-bffloor x)
+  (parameterize ([bf-precision (bigfloat-precision x)])
+    (bffloor x)))
+
+(define (ival-tgamma x)
+  (define logy (ival-lgamma x))
+  (unless logy
+    (error 'ival-lgamma "Invalid input to ival-lgamma: ~a" x))
+  (define absy (ival-exp logy))
+  (define lo (ival-lo-val x))
+  (define hi (ival-hi-val x))
+  (cond
+   [(bfgte? lo 0.bf)
+    absy]
+   [(not (bf=? (exact-bffloor lo) (exact-bffloor hi)))
+    (ival (endpoint -inf.bf (ival-lo-fixed? x))
+          (endpoint +inf.bf (ival-hi-fixed? x))
+          #t (ival-err x))]
+   [(and (not (bfpositive? lo)) (bf=? lo hi) (bfinteger? lo))
+    ival-illegal]
+   [(bfeven? (exact-bffloor lo))
+    absy]
+   [else
+    (ival-neg absy)]))


### PR DESCRIPTION
This PR fixes #64, which turns out to be an issue with the handling of negative infinite endpoints in `lgamma`.