### PR TITLE
Fix some invalid points sampled as valid

### DIFF
--- a/eval/run.rkt
+++ b/eval/run.rkt
@@ -93,7 +93,7 @@
         [(ival-err? out) (set! good? #f)])
       (vector-set! slackvec n (= distance 1))
       lo))
-  (values good? done? bad? stuck? fvec))
+  (values good? (and good? done?) bad? stuck? fvec))
 
 (define (rival-machine-adjust machine)
   (define iter (rival-machine-iteration machine))


### PR DESCRIPTION
Sometimes, a point was sampled as valid even though it was invalid:
```
> (eval (sqrt (- (exp -1e100))))
0.0
```
This is because `sqrt` was returning the interval `[0, 0]` with the `err?` flag set, and then this was being taken as a point interval. This PR fixes it.