### PR TITLE
Target precisions in discretizations

### DIFF
--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -219,7 +219,7 @@
   (define ivec-len (vector-length ivec))
   (define vstart-precs (make-vector ivec-len 0))
 
-  (for ([root (in-vector roots)] [disc (in-list discs)])
+  (for ([root (in-vector roots)] [disc (in-list discs)] #:when (>= root varc))
     (vector-set! vstart-precs (- root varc)
                  (+ (discretization-target disc) (*base-tuning-precision*))))
 

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -8,7 +8,7 @@
 (define *rival-max-iterations* (make-parameter 5))
 (define *rival-profile-executions* (make-parameter 1000))
 
-(struct discretization (convert distance))
+(struct discretization (target convert distance))
 
 (struct rival-machine
   (arguments instructions outputs discs
@@ -19,5 +19,5 @@
 
 (define *ampl-tuning-bits* (make-parameter 5))
 (define *sampling-iteration* (make-parameter 0))
-(define *base-tuning-precision* (make-parameter 73))
+(define *base-tuning-precision* (make-parameter 20))
 

--- a/eval/run.rkt
+++ b/eval/run.rkt
@@ -71,7 +71,6 @@
   (define vregs (rival-machine-registers machine))
   (define rootvec (rival-machine-outputs machine))
   (define slackvec (rival-machine-output-distance machine))
-  #;(set-rival-machine-iteration! machine (add1 (rival-machine-iteration machine)))
   (define ovec (make-vector (vector-length rootvec)))
   (define good? #t)
   (define done? #t)

--- a/repl.rkt
+++ b/repl.rkt
@@ -1,13 +1,8 @@
 #lang racket
 
 (require (only-in math/private/bigfloat/mpfr bfcopy bigfloats-between bf-precision bigfloat->string bf))
-(require "eval/main.rkt" "eval/machine.rkt")
+(require "eval/main.rkt" "eval/machine.rkt" "utils.rkt")
 (provide rival-repl)
-
-(define (bf-discretization n)
-  (discretization
-   (lambda (x) (parameterize ([bf-precision n]) (bfcopy x)))
-   (lambda (x y) (parameterize ([bf-precision n]) (abs (bigfloats-between x y))))))
 
 (define (fix-up-fpcore expr)
   (match expr

--- a/scribblings/eval.scrbl
+++ b/scribblings/eval.scrbl
@@ -73,21 +73,28 @@ To define the floating-point format that Rival is supposed to compute
 the output in, you provide a "discretization".
 
 @defstruct*[discretization
-  ([convert (-> (or/c bigfloat? boolean?) T)]
+  ([target integer?]
+   [convert (-> (or/c bigfloat? boolean?) T)]
    [distance (-> T T integer?)])]{
-A discretization represents some subset of the real numbers.
-The @racket[convert] function converts a bigfloat value to
-some type (for example, @racket[flonum?]), while the @racket[distance]
-function determines how close two estimates of a value are.
-
+A discretization represents some subset of the real numbers
+  (for example, @racket[flonum?]).
+The @racket[target] describes
+  the @racket[bf-precision] needed
+  to exactly represent a value in the subset,
+  the @racket[convert] function converts
+  a bigfloat value to a value in the subset,
+  and the @racket[distance]
+  function determines how close two values in the subset are.
 A distance of @racket[0] indicates that the two values are equal.
-A distance of @racket[2] or greater indicates that the two values
-are far apart. A value of exactly @racket[1] indicates that
-the two values share a rounding boundary; this triggers special
-behavior inside Rival to handle double-rounding issues.
-
-Note that (the absolute value of) @racket[flonums-between?] already
-returns values that fit these requirements.
+A distance of @racket[2] or greater indicates
+  that the two values are far apart.
+A value of exactly @racket[1] indicates
+  that the two values are sequential, that is,
+  that they share a rounding boundary.
+This last case triggers special behavior inside Rival
+  to handle double-rounding issues.
+Note that (the absolute value of) @racket[flonums-between?]
+  already returns values that fit these requirements.
 }
 
 The typical use case is evaluating an expression to double-precision

--- a/utils.rkt
+++ b/utils.rkt
@@ -5,13 +5,14 @@
 (provide flonum-discretization boolean-discretization bf-discretization)
 
 (define flonum-discretization
-  (discretization bigfloat->flonum (compose abs flonums-between)))
+  (discretization 53 bigfloat->flonum (compose abs flonums-between)))
 
 (define boolean-discretization
-  (discretization values (lambda (x y) (if (eq? x y) 0 2))))
+  (discretization 53 values (lambda (x y) (if (eq? x y) 0 2))))
 
 (define (bf-discretization [precision #f])
   (define n (or precision (bf-precision)))
   (discretization
+   n
    (lambda (x) (parameterize ([bf-precision n]) (bfcopy x)))
    (lambda (x y) (parameterize ([bf-precision n]) (abs (bigfloats-between x y))))))


### PR DESCRIPTION
This PR makes each discretization list a target precision instead of always defaulting to 73. Among other things, this makes `(set precision ...)` work in the REPL (#70). Previously, if you set a precision higher than 73, we'd never tune the precision high enough to converge.