### PR TITLE
Add support for `cosu` and friends

### DIFF
--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -43,12 +43,42 @@
      `(sqrt ,arg)]
 
     ; Special trigonometric functions
+    [`(cos (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
+     `((cosu ,(* 2 n)) ,x)]
     [`(cos (* (/ ,x ,(? (conjoin fixnum? positive?) n)) ,(or 'PI '(PI))))
      `((cosu ,(* 2 n)) ,x)]
+    [`(cos (* ,(or 'PI '(PI)) ,x))
+     `((cosu 2) ,x)]
     [`(cos (* ,x ,(or 'PI '(PI))))
      `((cosu 2) ,x)]
+    [`(cos (* (* 2 ,(or 'PI '(PI))) ,x))
+     `((cosu 1) ,x)]
     [`(cos (* ,x (* 2 ,(or 'PI '(PI)))))
      `((cosu 1) ,x)]
+    [`(sin (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
+     `((sinu ,(* 2 n)) ,x)]
+    [`(sin (* (/ ,x ,(? (conjoin fixnum? positive?) n)) ,(or 'PI '(PI))))
+     `((sinu ,(* 2 n)) ,x)]
+    [`(sin (* ,(or 'PI '(PI)) ,x))
+     `((sinu 2) ,x)]
+    [`(sin (* ,x ,(or 'PI '(PI))))
+     `((sinu 2) ,x)]
+    [`(sin (* (* 2 ,(or 'PI '(PI))) ,x))
+     `((sinu 1) ,x)]
+    [`(sin (* ,x (* 2 ,(or 'PI '(PI)))))
+     `((sinu 1) ,x)]
+    [`(tan (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
+     `((tanu ,(* 2 n)) ,x)]
+    [`(tan (* (/ ,x ,(? (conjoin fixnum? positive?) n)) ,(or 'PI '(PI))))
+     `((tanu ,(* 2 n)) ,x)]
+    [`(tan (* ,(or 'PI '(PI)) ,x))
+     `((tanu 2) ,x)]
+    [`(tan (* ,x ,(or 'PI '(PI))))
+     `((tanu 2) ,x)]
+    [`(tan (* (* 2 ,(or 'PI '(PI))) ,x))
+     `((tanu 1) ,x)]
+    [`(tan (* ,x (* 2 ,(or 'PI '(PI)))))
+     `((tanu 1) ,x)]
 
     ; Handle pow(x, 1/5) and similar
     [`(pow (fabs ,x) ,y)
@@ -196,6 +226,8 @@
         [(list 'pow2 x) (list ival-pow2 x)]
 
         [(list `(cosu ,n) x) (list (ival-cosu n) x)]
+        [(list `(sinu ,n) x) (list (ival-sinu n) x)]
+        [(list `(tanu ,n) x) (list (ival-tanu n) x)]
 
         [(list '== x y) (list ival-== x y)]
         [(list '!= x y) (list ival-!= x y)]

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -1,6 +1,6 @@
 #lang racket
 
-(require racket/match (only-in math/private/bigfloat/mpfr bfprev bf bf-rounding-mode bf=?) racket/flonum)
+(require racket/match (only-in "../mpfr.rkt" bfprev bf bfsinu bfcosu bftanu bf-rounding-mode bf=?) racket/flonum)
 (require "../ops/all.rkt" "machine.rkt")
 (provide rival-compile *rival-use-shorthands* *rival-name-constants*)
 
@@ -44,40 +44,58 @@
 
     ; Special trigonometric functions
     [`(cos (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
+     #:when bfcosu
      `((cosu ,(* 2 n)) ,x)]
     [`(cos (* (/ ,x ,(? (conjoin fixnum? positive?) n)) ,(or 'PI '(PI))))
+     #:when bfcosu
      `((cosu ,(* 2 n)) ,x)]
     [`(cos (* ,(or 'PI '(PI)) ,x))
+     #:when bfcosu
      `((cosu 2) ,x)]
     [`(cos (* ,x ,(or 'PI '(PI))))
+     #:when bfcosu
      `((cosu 2) ,x)]
     [`(cos (* (* 2 ,(or 'PI '(PI))) ,x))
+     #:when bfcosu
      `((cosu 1) ,x)]
     [`(cos (* ,x (* 2 ,(or 'PI '(PI)))))
+     #:when bfcosu
      `((cosu 1) ,x)]
     [`(sin (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
+     #:when bfsinu
      `((sinu ,(* 2 n)) ,x)]
     [`(sin (* (/ ,x ,(? (conjoin fixnum? positive?) n)) ,(or 'PI '(PI))))
+     #:when bfsinu
      `((sinu ,(* 2 n)) ,x)]
     [`(sin (* ,(or 'PI '(PI)) ,x))
+     #:when bfsinu
      `((sinu 2) ,x)]
     [`(sin (* ,x ,(or 'PI '(PI))))
+     #:when bfsinu
      `((sinu 2) ,x)]
     [`(sin (* (* 2 ,(or 'PI '(PI))) ,x))
+     #:when bfsinu
      `((sinu 1) ,x)]
     [`(sin (* ,x (* 2 ,(or 'PI '(PI)))))
+     #:when bfsinu
      `((sinu 1) ,x)]
     [`(tan (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
+     #:when bftanu
      `((tanu ,(* 2 n)) ,x)]
     [`(tan (* (/ ,x ,(? (conjoin fixnum? positive?) n)) ,(or 'PI '(PI))))
+     #:when bftanu
      `((tanu ,(* 2 n)) ,x)]
     [`(tan (* ,(or 'PI '(PI)) ,x))
+     #:when bftanu
      `((tanu 2) ,x)]
     [`(tan (* ,x ,(or 'PI '(PI))))
+     #:when bftanu
      `((tanu 2) ,x)]
     [`(tan (* (* 2 ,(or 'PI '(PI))) ,x))
+     #:when bftanu
      `((tanu 1) ,x)]
     [`(tan (* ,x (* 2 ,(or 'PI '(PI)))))
+     #:when bftanu
      `((tanu 1) ,x)]
 
     ; Handle pow(x, 1/5) and similar

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -52,6 +52,25 @@
   (mpfr-log2p1 out x (bf-rounding-mode))
   out)
 
+(define mpfr-cosu (get-mpfr-fun 'mpfr_cosu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int)))
+(define mpfr-sinu (get-mpfr-fun 'mpfr_sinu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int)))
+(define mpfr-tanu (get-mpfr-fun 'mpfr_tanu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int)))
+
+(define (bfcosu n x)
+  (define out (bf 0))
+  (mpfr-cosu out x n (bf-rounding-mode))
+  out)
+
+(define (bfsinu n x)
+  (define out (bf 0))
+  (mpfr-sinu out x n (bf-rounding-mode))
+  out)
+
+(define (bftanu n x)
+  (define out (bf 0))
+  (mpfr-tanu out x n (bf-rounding-mode))
+  out)
+
 (define (bflogb x)
   (bffloor (bflog2 (bfabs x))))
 
@@ -85,7 +104,7 @@
  bfrint bfround bfceiling bffloor bftruncate
  bfexp bflog bfexp2 bfexpm1 bflog2 bflog1p bflog10 bfexpt 
  bfsqrt bfcbrt bfhypot 
- bfsin bfcos bftan bfsinh bfcosh bftanh
+ bfsin bfcos bftan bfsinh bfcosh bftanh bfcosu bfsinu bftanu
  bfasin bfacos bfatan bfatan2 bfasinh bfacosh bfatanh
  bflog-gamma bfgamma bferf bferfc
  bfremainder bffmod bflogb bfcopysign bffdim and-fn or-fn if-fn bffma)

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -71,6 +71,10 @@
   (mpfr-tanu out x n (bf-rounding-mode))
   out)
 
+(unless mpfr-cosu (set! bfcosu #f))
+(unless mpfr-sinu (set! bfsinu #f))
+(unless mpfr-tanu (set! bftanu #f))
+
 (define (bflogb x)
   (bffloor (bflog2 (bfabs x))))
 

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -52,9 +52,9 @@
   (mpfr-log2p1 out x (bf-rounding-mode))
   out)
 
-(define mpfr-cosu (get-mpfr-fun 'mpfr_cosu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int)))
-(define mpfr-sinu (get-mpfr-fun 'mpfr_sinu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int)))
-(define mpfr-tanu (get-mpfr-fun 'mpfr_tanu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int)))
+(define mpfr-cosu (get-mpfr-fun 'mpfr_cosu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (const #f)))
+(define mpfr-sinu (get-mpfr-fun 'mpfr_sinu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (const #f)))
+(define mpfr-tanu (get-mpfr-fun 'mpfr_tanu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (const #f)))
 
 (define (bfcosu n x)
   (define out (bf 0))

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -52,9 +52,9 @@
   (mpfr-log2p1 out x (bf-rounding-mode))
   out)
 
-(define mpfr-cosu (get-mpfr-fun 'mpfr_cosu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (const #f)))
-(define mpfr-sinu (get-mpfr-fun 'mpfr_sinu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (const #f)))
-(define mpfr-tanu (get-mpfr-fun 'mpfr_tanu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (const #f)))
+(define mpfr-cosu (get-mpfr-fun 'mpfr_cosu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
+(define mpfr-sinu (get-mpfr-fun 'mpfr_sinu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
+(define mpfr-tanu (get-mpfr-fun 'mpfr_tanu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
 
 (define (bfcosu n x)
   (define out (bf 0))

--- a/ops/all.rkt
+++ b/ops/all.rkt
@@ -9,7 +9,7 @@
  ival-add ival-sub ival-neg ival-mult ival-div ival-fma       
  ival-fabs ival-sqrt ival-cbrt ival-hypot ival-exp ival-exp2 ival-expm1
  ival-log ival-log2 ival-log10 ival-log1p ival-logb ival-pow ival-pow2
- ival-cos ival-sin ival-tan ival-cosu
+ ival-cos ival-sin ival-tan ival-cosu ival-sinu ival-tanu
  ival-asin ival-acos ival-atan ival-atan2 ival-sinh ival-cosh ival-tanh
  ival-asinh ival-acosh ival-atanh ival-erf ival-erfc ival-lgamma ival-tgamma    
  ival-fmod ival-remainder ival-rint ival-round ival-ceil ival-floor ival-trunc     

--- a/ops/all.rkt
+++ b/ops/all.rkt
@@ -9,7 +9,7 @@
  ival-add ival-sub ival-neg ival-mult ival-div ival-fma       
  ival-fabs ival-sqrt ival-cbrt ival-hypot ival-exp ival-exp2 ival-expm1
  ival-log ival-log2 ival-log10 ival-log1p ival-logb ival-pow ival-pow2
- ival-sin ival-cos ival-tan
+ ival-cos ival-sin ival-tan ival-cosu
  ival-asin ival-acos ival-atan ival-atan2 ival-sinh ival-cosh ival-tanh
  ival-asinh ival-acosh ival-atanh ival-erf ival-erfc ival-lgamma ival-tgamma    
  ival-fmod ival-remainder ival-rint ival-round ival-ceil ival-floor ival-trunc     

--- a/ops/trig.rkt
+++ b/ops/trig.rkt
@@ -56,7 +56,7 @@
                 (endpoint 1.bf #f) (ival-err? x) (ival-err x))]
          [else
           (ival-then x (mk-big-ival -1.bf 1.bf))])]))
-  ival-cosu)
+  (if bfcosu ival-cosu #f))
 
 (define (ival-cos x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
@@ -116,7 +116,7 @@
                 (ival-err x))]
          [else
           (ival-then x (mk-big-ival -1.bf 1.bf))])]))
-  ival-sinu)
+  (if bfsinu ival-sinu #f))
 
 (define (ival-sin x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
@@ -163,7 +163,7 @@
            ((monotonic->ival (curry bftanu n)) x)
            (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!))
                  #t xerr))]))
-  ival-tanu)
+  (if bftanu ival-tanu #f))
 
 (define (ival-tan x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)

--- a/ops/trig.rkt
+++ b/ops/trig.rkt
@@ -1,7 +1,7 @@
 #lang racket
 
 (require "core.rkt" "../mpfr.rkt")
-(provide ival-sin ival-cos ival-tan)
+(provide ival-sin ival-cos ival-tan ival-cosu)
 
 (define *rival-precision* (make-parameter (expt 2 20)))
 
@@ -24,6 +24,39 @@
             (max
              (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
              (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi))))))
+
+(define (ival-cosu n)
+  (define (ival-cosu x)
+    (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
+    (match (classify-ival-periodic x n)
+      ['too-wide (ival-then x (mk-big-ival -1.bf 1.bf))]
+      ['near-0
+       (match (classify-ival x)
+         [-1 ((monotonic->ival (curry bfcosu n)) x)]
+         [ 1 ((comonotonic->ival (curry bfcosu n)) x)]
+         [else
+          (ival (rnd 'down epfn bfmin2 (epfn (curry bfcosu n) (ival-lo x))
+                     (epfn (curry bfcosu n) (ival-hi x)))
+                (endpoint 1.bf #f) (ival-err? x) (ival-err x))])]
+      ['range-reduce
+       (match-define (ival (endpoint a _) (endpoint b _) _ _)
+         (parameterize ([bf-precision (range-reduce-precision xlo xhi)])
+           (ival-floor (ival-div x (mk-ival (bf (/ n 2)))))))
+       (cond
+         [(and (bf=? a b) (bfeven? a))
+          ((comonotonic->ival (curry bfcosu n)) x)]
+         [(and (bf=? a b) (bfodd? a))
+          ((monotonic->ival (curry bfcosu n)) x)]
+         [(and (bf=? (bfsub b a) 1.bf) (bfeven? a))
+          (ival (endpoint -1.bf #f)
+                (rnd 'up epfn bfmax2 (epfn (curry bfcosu n) (ival-lo x)) (epfn (curry bfcosu n) (ival-hi x)))
+                (ival-err? x) (ival-err x))]
+         [(and (bf=? (bfsub b a) 1.bf) (bfodd? a))
+          (ival (rnd 'down epfn bfmin2 (epfn (curry bfcosu n) (ival-lo x)) (epfn (curry bfcosu n) (ival-hi x)))
+                (endpoint 1.bf #f) (ival-err? x) (ival-err x))]
+         [else
+          (ival-then x (mk-big-ival -1.bf 1.bf))])]))
+  ival-cosu)
 
 (define (ival-cos x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)


### PR DESCRIPTION
This PR adds the `cosu`, `tanu`, and `sinu` functions to Rival. It also treats them as shorthands for `(cos (* (/ x n) (PI)))` and similar. I didn't add every possible shorthand—there would be too many—but we can add them if necessary. The code for each function isn't that bad (though more compression is always nice).