### PR TITLE
Fix Rival on Windows by using `bfinfinite?` and `bfzero?`

### DIFF
--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -77,7 +77,7 @@
 
 (provide
  bf bigfloat? mpfr-sign bigfloat-exponent bigfloat-precision bf-precision mpfr-exp bf-rounding-mode
- bfpositive? bfinteger? bfzero? bfnan? bfinfinite? bfeven? bfodd? 
+ bfpositive? bfinteger? bfzero? bfnan? bfinfinite? bfnegative? bfeven? bfodd? 
  bfcopy bfstep bigfloats-between bfprev bfnext 
  bf=? bflte? bfgte? bflt? bfgt? bfgte? 
  pi.bf bfmin2 bfmax2


### PR DESCRIPTION
It looks like the special constants for the `mpfr-exp` of 0 and infinity are platform-specific somehow. Maybe it's 32-bit vs 64-bit? Or Windows ABI something something? Anyway, better not to mess with it.