### PR TITLE
Switch to `raco fmt` for formatting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,5 +20,5 @@ jobs:
       - name: "Reformat all of the source code"
         run: raco fmt -i **/*.rkt
       - name: "Make sure files are correctly formatted with raco fmt"
-        run: git diff --quiet
+        run: git diff --exit-code
       - run: raco test *.rkt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Install dependencies"
         run: raco pkg install --name rival --no-cache --auto
       - name: "Install raco fmt"
-        run: raco pkg install fmt
+        run: raco pkg install --auto fmt
       - name: "Reformat all of the source code"
         run: raco fmt -i **/*.rkt
       - name: "Make sure files are correctly formatted with raco fmt"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,4 +15,10 @@ jobs:
       - uses: actions/checkout@master
       - name: "Install dependencies"
         run: raco pkg install --name rival --no-cache --auto
+      - name: "Install raco fmt"
+        run: raco pkg install fmt
+      - name: "Reformat all of the source code"
+        run: raco fmt -i **/*.rkt
+      - name: "Make sure files are correctly formatted with raco fmt"
+        run: git diff --quiet
       - run: raco test *.rkt

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: nightly 
+.PHONY: nightly hook
 
 
 
@@ -6,3 +6,6 @@ nightly:
 	bash infra/nightly.sh perf
 	nightly-results publish report/
 
+hook:
+	echo "#!/bin/sh" >.git/hooks/pre-commit
+	echo "raco fmt -i \$$(find . -name '*.rkt')" >>.git/hooks/pre-commit

--- a/README.md
+++ b/README.md
@@ -1,132 +1,62 @@
 Interval Arithmetic for Real Computation
 ========================================
 
-Rival is an interval arithmetic library for Racket, intended for real
-computation. Rival supports Racket 7.0+ and depends only on the
-standard `math` library, including `math/bigfloat`.
+Rival is a library for evaluating real expressions to high precision.
+Rival supports Racket 8.0+ and depends only on the standard `math`
+library, including `math/bigfloat`.
 
 Using Rival
 -----------
 
-Rival's main data structure is the `ival`, which represents the set of
-extended real numbers between two points (inclusive both ends). Real
-numbers, for Rival, are represented by bigfloats. For example:
+Rival is easiest to use from its REPL:
 
-    > (require rival math/bigfloat)
-    > (ival 2.bf 3.bf)
-    (ival 2 3)
+    $ racket -l rival
+    > (eval (sin 1e100))
+    -0.3723761236612767
+    > (set precision 1000)
+    > (eval (sin 1e100))
+    -0.3723761236612766882620866955531642957...
+    > (set precision 100)
+    > (define (f x) (- (sin x) (- x (/ (pow x 3) 6))))
+    > (eval f 1e-100)
+    8.3333333333333333333333333333237e-503
 
-You can also easily create single-point intervals with `mk-ival`:
+The [full
+documentation](https://docs.racket-lang.org/rival/index.html)
+describes the Racket API and the underlying interval library.
 
-    > (ival 2.bf 2.bf)
-    (ival 2 2)
-    > (mk-ival 2.bf)
-    (ival 2 2)
+Features
+--------
 
-Rival provides interval implementations of all of the standard
-arithmetic functions:
+Rival provides a number of advanced features, which we believe makes
+Rival the state of the art real evaluation library:
 
-    > (ival-mult (ival 2.bf 3.bf) (ival 1.bf 2.bf))
-    (ival 2 6)
-    > (ival-sin (ival 2.bf 3.bf))
-    (ival 0.1411... 0.9092...)
+- Support for all `math.h` functions, including arithmetic,
+  trigonometric, power, remainder, rounding, and even gamma functions.
+- Support for comparisons, conditionals, and boolean operations
+  through boolean intervals
+- Sound handling of domain errors through error intervals
+- Fast and accurate mixed-precision assignments for evaluation
+- Correct rounding
+- Early exit using movability flags
+- Well-tested soundness and robustness
 
-Note intervals are always rounded outwards. Functions like `remainder`
-and `pow` match their counterparts in C's `math.h`.
-
-Control flow
+Contributing
 ------------
 
-Rival supports _boolean intervals_, where the bounds of the intervals
-are booleans instead of real numbers. This allows Rival to support
-comparisons, boolean operations, and conditionals:
+Please file issues and submit patches [on
+Github](https://github.com/herbie-fp/rival). All code should be
+formatted using `raco fmt`; you can set this up to happen on commit
+with:
 
-    > (ival-< (ival 1.bf 3.bf) (ival 2.bf 4.bf))
-    (ival #f #t)
-    > (ival-and (ival-< (ival 1.bf 3.bf) (ival 2.bf 4.bf))
-                (ival-bool #f))
-    (ival #f #f)
-    > (if (ival #f #t)
-          (ival 1.bf 2.bf)
-          (ival 3.bf 4.bf))
-    (ival 1.bf 4.bf)
+    make hook
 
-In addition, intervals contain _error intervals_ tracking whether any
-functions could/must be called outside their domain. These are
-accessible with `ival-err?` and `ival-err`. For example, since square
-root is defined only for positive values, calling it on `[-1, 1]`
-could, but doesn't have to, raise an error:
+Additionally, all code must pass the automated tests, which you can
+run with:
 
-    > (define i (ival-sqrt (ival -1.bf 1.bf)))
-    > i
-    (ival 0 1)
-    > (ival-err? i)
-    #t
-    > (ival err i)
-    #f
+    raco test test.rkt
 
-Meanwhile, calling it on `[-2, -1]` always produces an error:
+They also run in CI before merging. Finally, performance is a key
+metric for Rival; you can run the automated performance tests with:
 
-    > (define i (ival-sqrt (ival -2.bf -1.bf)))
-    > i
-    (ival +nan.bf +nan.bf)
-    > (ival-err? i)
-    #t
-    > (ival err i)
-    #t
-
-Movability
-----------
-
-Since Rival internally uses bigfloat computation, it is sensitive to
-bigfloat rounding. Intervals may shrink (though they cannot grow) when
-computed at a higher precision. However, in some cases it is known
-this will not occur, largely due to overflow. In those cases, the
-interval is marked fixed, or immovable:
-
-    > (ival-exp (mk-ival (bf 1e100)))
-    (ival ... +inf.bf)
-    > (ival-hi-fixed? (ival-exp (mk-ival (bf 1e100))))
-    #t
-
-Movability flags are propagated
-
-Rival's guarantees
-------------------
-
-Rival attempts to guarantee (and has random tests for) the following
-properties:
-
- + If `x ∈ I`, `f(x) ∈ f(I)`,
-   where both functions are computed at the same biginterval precision.
- + If `f(I) = [l, h]`, then `∃ x ∈ I, f(x) = l` (if `f` rounds down),
-   and likewise for `h`.
-
-Completeness may be violated in edge cases for complex functions such
-as `fmod` and `pow`.
-
-Error flags also aim to be sound and complete:
-
- + If `f(x)` raises an error and `x ∈ I`, then `err?(f(I))`.
- + If `err?(f(I))`, then `∃ x ∈ I` such that `f(x)` raises an error
-
-However, Rival sometimes idiosyncratically interprets some error
-conditions as valid. For example, `sin(+inf.bf)` is interpreted as the
-_interval_ `[-1, 1]` instead of as an error condition; this impacts
-both soundness and completeness.
-
-Finally movability flags aim at soundness, though not yet completeness:
-
- + If `f(I).hi.fixed?` at a precision `p`,
-   then `f(I).hi` is the same at all precisions `q > p`
-   
-Besides functional correctness, Rival guarantees termination for each
-operation and error-freedom for correctly-invoked operations. (Its
-contracts are not yet strong enough to prevent ill-typed invocations.)
-
-Speed is fairly good, with attention paid to avoid unnecessary
-bigfloat computations.
-
-Please report any failures of any of the above properties as bugs.
-
-
+    racket -y time.rkt

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -1,7 +1,11 @@
 #lang racket/base
 
-(require racket/function racket/list racket/match)
-(require "../mpfr.rkt" "../ops/all.rkt" "machine.rkt")
+(require racket/function
+         racket/list
+         racket/match)
+(require "../mpfr.rkt"
+         "../ops/all.rkt"
+         "machine.rkt")
 (provide backward-pass)
 
 (define (backward-pass machine)
@@ -19,11 +23,14 @@
   (define bumps (rival-machine-bumps machine))
 
   (define varc (vector-length args))
-  (define vprecs-new (make-vector (vector-length ivec) 0))          ; new vprecs vector
+  (define vprecs-new (make-vector (vector-length ivec) 0)) ; new vprecs vector
 
   ; Step 1. Adding slack in case of a rounding boundary issue
-  (for ([root-reg (in-vector rootvec)] [disc (in-vector discs)] [out-dr? (in-vector slackvec)]
-        #:when (>= root-reg varc) #:when out-dr?)
+  (for ([root-reg (in-vector rootvec)]
+        [disc (in-vector discs)]
+        [out-dr? (in-vector slackvec)]
+        #:when (>= root-reg varc)
+        #:when out-dr?)
     (vector-set! vprecs-new (- root-reg varc) (get-slack)))
 
   ; Step 1b. Checking if a operation should be computed again at all
@@ -35,11 +42,10 @@
         [i (in-range (- (vector-length ivec) 1) -1 -1)]
         [useful? (in-vector vuseful (- (vector-length vuseful) 1) -1 -1)])
     (cond
-     [(and (ival-lo-fixed? reg) (ival-hi-fixed? reg))
-      (vector-set! vuseful i #f)]
-     [useful?
-      (for ([arg (in-list (cdr instr))] #:when (>= arg varc))
-        (vector-set! vuseful (- arg varc) #t))]))
+      [(and (ival-lo-fixed? reg) (ival-hi-fixed? reg)) (vector-set! vuseful i #f)]
+      [useful?
+       (for ([arg (in-list (cdr instr))] #:when (>= arg varc))
+         (vector-set! vuseful (- arg varc) #t))]))
 
   ; Step 2. Precision tuning
   (precision-tuning ivec vregs vprecs-new varc vstart-precs vuseful)
@@ -55,8 +61,7 @@
         [n (in-naturals)])
     (define repeat
       (and (<= prec-new prec-old)
-           (andmap (lambda (x) (or (< x varc) (vector-ref vrepeats (- x varc))))
-                   (cdr instr))))
+           (andmap (lambda (x) (or (< x varc) (vector-ref vrepeats (- x varc)))) (cdr instr))))
     (set! any-false? (or any-false? (not repeat)))
     (vector-set! vrepeats n repeat))
 
@@ -67,10 +72,10 @@
   (unless any-false?
     (set-rival-machine-bumps! machine (add1 bumps))
     (define slack (get-slack))
-    (for ([prec (in-vector vprecs)]
-          [n (in-range (vector-length vprecs))])
+    (for ([prec (in-vector vprecs)] [n (in-range (vector-length vprecs))])
       (define prec* (min (*rival-max-precision*) (+ prec slack)))
-      (when (equal? prec* (*rival-max-precision*)) (*sampling-iteration* (*rival-max-iterations*)))
+      (when (equal? prec* (*rival-max-precision*))
+        (*sampling-iteration* (*rival-max-iterations*)))
       (vector-set! vprecs n prec*))
     (vector-fill! vrepeats #f)))
 
@@ -79,26 +84,25 @@
 ;   vprecs-new[i] = min( *rival-max-precision* max( *base-tuning-precision* (+ intro vstart-precs[i])),
 ;   intro = get-ampls(parent)
 (define (precision-tuning ivec vregs vprecs-new varc vstart-precs vuseful)
-  (for ([instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)]   ; reversed over ivec
+  (for ([instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)] ; reversed over ivec
         [useful? (in-vector vuseful (- (vector-length vuseful) 1) -1 -1)]
         [n (in-range (- (vector-length vregs) 1) -1 -1)]
-        #:when useful?)           ; reversed over indices of vregs
+        #:when useful?) ; reversed over indices of vregs
 
-    (define op (car instr))                                         ; current operation
+    (define op (car instr)) ; current operation
     (define tail-registers (cdr instr))
     (define srcs (map (lambda (x) (vector-ref vregs x)) tail-registers)) ; tail of the current instr
-    (define output (vector-ref vregs n))                            ; output of the current instr
-    
-    (define intro (vector-ref vprecs-new (- n varc)))               ; intro for the current instruction
-    (define ampls (get-ampls op output srcs))                       ; ampls for the tail instructions
+    (define output (vector-ref vregs n)) ; output of the current instr
 
-    (define final-parent-precision (max (+ intro
-                                           (vector-ref vstart-precs (- n varc)))
-                                        (*base-tuning-precision*)))
-    
-    (when (>= final-parent-precision (*rival-max-precision*))       ; Early stopping
+    (define intro (vector-ref vprecs-new (- n varc))) ; intro for the current instruction
+    (define ampls (get-ampls op output srcs)) ; ampls for the tail instructions
+
+    (define final-parent-precision
+      (max (+ intro (vector-ref vstart-precs (- n varc))) (*base-tuning-precision*)))
+
+    (when (>= final-parent-precision (*rival-max-precision*)) ; Early stopping
       (*sampling-iteration* (*rival-max-iterations*)))
-    
+
     ; Final precision assignment
     (vector-set! vprecs-new (- n varc) (min final-parent-precision (*rival-max-precision*)))
 
@@ -119,108 +123,93 @@
   (define lo (ival-lo x))
   (define hi (ival-hi x))
   (cond
-    [(and (bfinfinite? hi) (bfinfinite? lo))                 ; x = [-inf, inf]
-     (get-slack)]
-    [(bfinfinite? hi)
-     (+ (max (mpfr-exp lo) 0) (get-slack))]        ; x = [..., inf]
-    [(bfinfinite? lo)
-     (+ (max (mpfr-exp hi) 0) (get-slack))]        ; x = [-inf, ...]
+    ; x = [-inf, inf]
+    [(and (bfinfinite? hi) (bfinfinite? lo)) (get-slack)]
+    [(bfinfinite? hi) (+ (max (mpfr-exp lo) 0) (get-slack))] ; x = [..., inf]
+    [(bfinfinite? lo) (+ (max (mpfr-exp hi) 0) (get-slack))] ; x = [-inf, ...]
     [else
-     (+ (max (mpfr-exp lo) (mpfr-exp hi)) 1)]))    ; x does not contain inf, safe with respect to 0.bf
+     (+ (max (mpfr-exp lo) (mpfr-exp hi)) 1)])) ; x does not contain inf, safe with respect to 0.bf
 
 (define (minlog x)
   (define lo (ival-lo x))
   (define hi (ival-hi x))
   (cond
-    [(bfzero? lo)                                     ; x = [0.bf, ...]
-     (if (bfinfinite? hi)
-         (- (get-slack))
-         (- (min (mpfr-exp hi) 0) (get-slack)))]
-    [(bfzero? hi)                                     ; x = [..., 0.bf]
-     (if (bfinfinite? lo)
-         (- (get-slack))
-         (- (min (mpfr-exp lo) 0) (get-slack)))]
-    [(crosses-zero? x)                                ; x = [-..., +...]
+    ; x = [0.bf, ...]
+    [(bfzero? lo) (if (bfinfinite? hi) (- (get-slack)) (- (min (mpfr-exp hi) 0) (get-slack)))]
+    ; x = [..., 0.bf]
+    [(bfzero? hi) (if (bfinfinite? lo) (- (get-slack)) (- (min (mpfr-exp lo) 0) (get-slack)))]
+    [(crosses-zero? x) ; x = [-..., +...]
      (cond
-       [(and (bfinfinite? hi) (bfinfinite? lo))
-        (- (get-slack))]
-       [(bfinfinite? hi)
-        (- (min (mpfr-exp lo) 0) (get-slack))]
-       [(bfinfinite? lo)
-        (- (min (mpfr-exp hi) 0) (get-slack))]
-       [else
-        (- (min (mpfr-exp lo) (mpfr-exp hi) 0) (get-slack))])]
+       [(and (bfinfinite? hi) (bfinfinite? lo)) (- (get-slack))]
+       [(bfinfinite? hi) (- (min (mpfr-exp lo) 0) (get-slack))]
+       [(bfinfinite? lo) (- (min (mpfr-exp hi) 0) (get-slack))]
+       [else (- (min (mpfr-exp lo) (mpfr-exp hi) 0) (get-slack))])]
     [else
      (cond
        ; Can't both be inf, since:
        ;  - [inf, inf] not a valid interval
        ;  - [-inf, inf] crosses zero
-       [(bfinfinite? lo)
-        (mpfr-exp hi)]
-       [(bfinfinite? hi)
-        (mpfr-exp lo)]
-       [else
-        (min (mpfr-exp lo) (mpfr-exp hi))])]))
+       [(bfinfinite? lo) (mpfr-exp hi)]
+       [(bfinfinite? hi) (mpfr-exp lo)]
+       [else (min (mpfr-exp lo) (mpfr-exp hi))])]))
 
 (define (logspan x)
   #;(define lo (ival-lo x))
   #;(define hi (ival-hi x))
   #;(if (or (bfzero? lo) (bfinfinite? lo) (bfzero? hi) (bfinfinite? hi))
-      (get-slack)
-      (+ (abs (- (mpfr-exp lo) (mpfr-exp hi))) 1))
+        (get-slack)
+        (+ (abs (- (mpfr-exp lo) (mpfr-exp hi))) 1))
   0)
 
 ; Function calculates an ampl factor per input for a certain output and inputs using condition formulas,
 ;   where an ampl is an additional precision that needs to be added to srcs evaluation so,
 ;   that the output will be fixed in its precision when evaluating again
 (define (get-ampls op z srcs)
-  (case (object-name  op)
+  (case (object-name op)
     [(ival-mult)
      ; k = 1: logspan(y)
      ; k = 2: logspan(x)
      (define x (first srcs))
      (define y (second srcs))
-     (list (logspan y)                                ; exponent per x
-           (logspan x))]                              ; exponent per y
-    
+     (list (logspan y) ; exponent per x
+           (logspan x))] ; exponent per y
+
     [(ival-div)
      ; k = 1: logspan(y)
      ; k = 2: logspan(x) + 2 * logspan(y)
      (define x (first srcs))
      (define y (second srcs))
-     (list (logspan y)                                ; exponent per x
-           (+ (logspan x) (* 2 (logspan y))))]        ; exponent per y
+     (list (logspan y) ; exponent per x
+           (+ (logspan x) (* 2 (logspan y))))] ; exponent per y
 
     [(ival-sqrt ival-cbrt)
      ; sqrt: logspan(x)/2 - 1
      ; cbrt: logspan(x)*2/3 - 1
      (define x (first srcs))
      (list (quotient (logspan x) 2))]
-    
+
     [(ival-add ival-sub)
      ; k = 1: maxlog(x) - minlog(z)
      ; k = 2: maxlog(y) - minlog(z)
      (define x (first srcs))
      (define y (second srcs))
-     
-     (list (- (maxlog x) (minlog z))                  ; exponent per x
-           (- (maxlog y) (minlog z)))]                ; exponent per y 
-    
+
+     (list (- (maxlog x) (minlog z)) ; exponent per x
+           (- (maxlog y) (minlog z)))] ; exponent per y
+
     [(ival-pow)
      ; k = 1: maxlog(y) + logspan(x) + logspan(z)
      ; k = 2: maxlog(y) + max(|minlog(x)|,|maxlog(x)|) + logspan(z)
      (define x (first srcs))
      (define y (second srcs))
-     
+
      ; when output crosses zero and x is negative - means that y was fractional and not fixed (specific of Rival)
      ; solution - add more slack for y to converge
-     (define slack (if (and (crosses-zero? z) (bfnegative? (ival-lo x)))
-                       (get-slack)
-                       0))
-        
-     (list (+ (maxlog y) (logspan x) (logspan z))     ; exponent per x
-           (+ (maxlog y) (max (abs (maxlog x)) (abs (minlog x))) (logspan z) slack))]  ; exponent per y
-     
+     (define slack (if (and (crosses-zero? z) (bfnegative? (ival-lo x))) (get-slack) 0))
+
+     (list (+ (maxlog y) (logspan x) (logspan z)) ; exponent per x
+           (+ (maxlog y) (max (abs (maxlog x)) (abs (minlog x))) (logspan z) slack))] ; exponent per y
+
     [(ival-exp ival-exp2)
      ; maxlog(x) + logspan(z)
      (define x (car srcs))
@@ -250,7 +239,7 @@
      ; maxlog(x) + logspan(z) + min(maxlog(x), 0)
      (define x (first srcs))
      (list (+ (maxlog x) (logspan z) (min (maxlog x) 0)))]
-    
+
     [(ival-log ival-log2 ival-log10)
      ; log:   logspan(x) - minlog(z)
      ; log2:  logspan(x) - minlog(z) + 1
@@ -263,10 +252,11 @@
      ;             ^^^^^^^^^^^^
      ;             condition of uncertainty
      (define x (first srcs))
-     (define slack (if (>= (maxlog z) 2)              ; Condition of uncertainty
-                       (get-slack)                    ; assumes that log[1-x^2]/2 is equal to slack
-                       0))
-     
+     (define slack
+       (if (>= (maxlog z) 2) ; Condition of uncertainty
+           (get-slack) ; assumes that log[1-x^2]/2 is equal to slack
+           0))
+
      (list (+ (- (maxlog x) (minlog z)) slack))]
 
     [(ival-acos)
@@ -274,12 +264,13 @@
      ;             ^^^^^^^^^^^^
      ;             condition of uncertainty
      (define x (first srcs))
-     (define slack (if (>= (maxlog x) 1)              ; Condition of uncertainty
-                       (get-slack)                    ; assumes that log[1-x^2]/2 is equal to slack
-                       0))
-     
+     (define slack
+       (if (>= (maxlog x) 1) ; Condition of uncertainty
+           (get-slack) ; assumes that log[1-x^2]/2 is equal to slack
+           0))
+
      (list (+ (- (maxlog x) (minlog z)) slack))]
-    
+
     [(ival-atan)
      ; logspan(x) - min(|minlog(x)|, |maxlog(x)|) - minlog(z)
      (define x (first srcs))
@@ -293,14 +284,15 @@
      ;                           conditions of uncertainty
      (define x (first srcs))
      (define y (second srcs))
-     
-     (define slack (if (crosses-zero? y)
-                       (get-slack)                    ; y crosses zero     
-                       0))                  
-     
-     (list (- (maxlog x) (minlog z))                  ; exponent per x
-           (+ (- (maxlog x) (minlog z)) slack))]      ; exponent per y
-    
+
+     (define slack
+       (if (crosses-zero? y)
+           (get-slack) ; y crosses zero
+           0))
+
+     (list (- (maxlog x) (minlog z)) ; exponent per x
+           (+ (- (maxlog x) (minlog z)) slack))] ; exponent per y
+
     ; Currently log1p has a very poor approximation
     [(ival-log1p)
      ; maxlog(x) - log[1+x] - minlog(z)
@@ -309,12 +301,12 @@
      (define x (first srcs))
      (define xhi (ival-hi x))
      (define xlo (ival-lo x))
-     
-     (define slack (if (or (equal? (mpfr-sign xlo) -1)
-                           (equal? (mpfr-sign xhi) -1))
-                       (get-slack)                    ; if x in negative
-                       0))
-     
+
+     (define slack
+       (if (or (equal? (mpfr-sign xlo) -1) (equal? (mpfr-sign xhi) -1))
+           (get-slack) ; if x in negative
+           0))
+
      (list (+ (- (maxlog x) (minlog z)) slack))]
 
     ; Currently expm1 has a very poor solution for negative values
@@ -322,14 +314,14 @@
      ; log[Гexpm1] = log[x * e^x / expm1] <= max(1 + maxlog(x), 1 + maxlog(x) - minlog(z))
      (define x (first srcs))
      (list (max (+ 1 (maxlog x)) (+ 1 (- (maxlog x) (minlog z)))))]
-    
+
     [(ival-atan2)
      ; maxlog(x) + maxlog(y) - 2*max(minlog(x), minlog(y)) - minlog(z)
      (define x (first srcs))
      (define y (second srcs))
-     
+
      (make-list 2 (- (+ (maxlog x) (maxlog y)) (* 2 (max (minlog x) (minlog y))) (minlog z)))]
-    
+
     [(ival-tanh)
      ; logspan(z) + logspan(x)
      (define x (first srcs))
@@ -340,32 +332,29 @@
      ;                               ^^^^^^^
      ;                           a possible uncertainty
      (define x (first srcs))
-     (list (if (>= (maxlog x) 1)
-               (get-slack)
-               1))]
+     (list (if (>= (maxlog x) 1) (get-slack) 1))]
 
     [(ival-acosh)
      ; log[Гacosh] = log[x / (sqrt(x-1) * sqrt(x+1) * acosh)] <= -minlog(z) + slack
      (define z-exp (minlog z))
-     (define slack (if (< z-exp 2)                    ; when acosh(x) < 1
-                       (get-slack)
-                       0))
-     
+     (define slack
+       (if (< z-exp 2) ; when acosh(x) < 1
+           (get-slack)
+           0))
+
      (list (- slack z-exp))]
 
     [(ival-pow2)
      ; same as multiplication
      (define x (first srcs))
      (list (+ (logspan x) 1))]
-    
+
     ; TODO
-    [(ival-erfc ival-erf ival-lgamma ival-tgamma ival-asinh ival-logb)
-     (list (get-slack))]
+    [(ival-erfc ival-erf ival-lgamma ival-tgamma ival-asinh ival-logb) (list (get-slack))]
     ; TODO
-    [(ival-ceil ival-floor ival-rint ival-round ival-trunc)
-     (list (get-slack))]
-    
-    [else (map (const 0) srcs)]))        ; exponents for arguments
+    [(ival-ceil ival-floor ival-rint ival-round ival-trunc) (list (get-slack))]
+
+    [else (map (const 0) srcs)])) ; exponents for arguments
 
 (define (get-slack)
   (match (*sampling-iteration*)

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -1,8 +1,13 @@
 #lang racket/base
 
-(provide (struct-out discretization) (struct-out rival-machine)
-         *rival-max-precision* *rival-max-iterations* *rival-profile-executions*
-         *ampl-tuning-bits* *sampling-iteration* *base-tuning-precision*)
+(provide (struct-out discretization)
+         (struct-out rival-machine)
+         *rival-max-precision*
+         *rival-max-iterations*
+         *rival-profile-executions*
+         *ampl-tuning-bits*
+         *sampling-iteration*
+         *base-tuning-precision*)
 
 (define *rival-max-precision* (make-parameter 10000))
 (define *rival-max-iterations* (make-parameter 5))
@@ -11,13 +16,22 @@
 (struct discretization (target convert distance))
 
 (struct rival-machine
-  (arguments instructions outputs discs
-   registers repeats precisions initial-precisions output-distance
-   [iteration #:mutable] [bumps #:mutable]
-   [profile-ptr #:mutable]
-   profile-instruction profile-number profile-time profile-precision))
+        (arguments instructions
+                   outputs
+                   discs
+                   registers
+                   repeats
+                   precisions
+                   initial-precisions
+                   output-distance
+                   [iteration #:mutable]
+                   [bumps #:mutable]
+                   [profile-ptr #:mutable]
+                   profile-instruction
+                   profile-number
+                   profile-time
+                   profile-precision))
 
 (define *ampl-tuning-bits* (make-parameter 5))
 (define *sampling-iteration* (make-parameter 0))
 (define *base-tuning-precision* (make-parameter 20))
-

--- a/eval/run.rkt
+++ b/eval/run.rkt
@@ -1,8 +1,16 @@
 #lang racket/base
 
-(require racket/match racket/function racket/flonum)
-(require "machine.rkt" "adjust.rkt" "../mpfr.rkt" "../ops/all.rkt")
-(provide rival-machine-load rival-machine-run rival-machine-return rival-machine-adjust)
+(require racket/match
+         racket/function
+         racket/flonum)
+(require "machine.rkt"
+         "adjust.rkt"
+         "../mpfr.rkt"
+         "../ops/all.rkt")
+(provide rival-machine-load
+         rival-machine-run
+         rival-machine-return
+         rival-machine-adjust)
 
 (define (rival-machine-load machine args)
   (vector-copy! (rival-machine-registers machine) 0 args)
@@ -54,17 +62,10 @@
   ;; becomes the fastest option.
   (match instr
     [(list op) (op)]
-    [(list op a)
-     (op (vector-ref regs a))]
-    [(list op a b)
-     (op (vector-ref regs a)
-         (vector-ref regs b))]
-    [(list op a b c)
-     (op (vector-ref regs a)
-         (vector-ref regs b)
-         (vector-ref regs c))]
-    [(list op args ...)
-     (apply op (map (curryr vector-ref regs) args))]))
+    [(list op a) (op (vector-ref regs a))]
+    [(list op a b) (op (vector-ref regs a) (vector-ref regs b))]
+    [(list op a b c) (op (vector-ref regs a) (vector-ref regs b) (vector-ref regs c))]
+    [(list op args ...) (apply op (map (curryr vector-ref regs) args))]))
 
 (define (rival-machine-return machine)
   (define discs (rival-machine-discs machine))

--- a/info.rkt
+++ b/info.rkt
@@ -16,4 +16,3 @@
 (define deps '(("base" #:version "8.0") "math-lib" "rackunit-lib" "profile-lib"))
 (define build-deps '("rackunit-lib" "scribble-lib" "racket-doc" "math-doc" "sandbox-lib"))
 (define scribblings '(("scribblings/rival.scrbl" (multi-page) (library))))
-

--- a/infra/format-mathematica.rkt
+++ b/infra/format-mathematica.rkt
@@ -2,15 +2,24 @@
 
 (require biginterval)
 
-
 (require math/bigfloat)
 (require "../main.rkt")
 
-(provide (struct-out mdata) collect-mathematica)
-(provide samplable? get-low get-hi bf-list->bf)
+(provide (struct-out mdata)
+         collect-mathematica)
+(provide samplable?
+         get-low
+         get-hi
+         bf-list->bf)
 
 ;; samplable + unsamplable is total points
-(struct mdata (rival-error-hash rival-samplable rival-movability rival-possible mathematica-samplable mathematica-unsamplable mathematica-error))
+(struct mdata
+        (rival-error-hash rival-samplable
+                          rival-movability
+                          rival-possible
+                          mathematica-samplable
+                          mathematica-unsamplable
+                          mathematica-error))
 
 (define (samplable? left right)
   (define <-bf bigfloat->flonum)
@@ -26,51 +35,38 @@
 (define (get-hi ival)
   (get-endpoint-val (vector-ref ival 2)))
 
-
 (define (is-nan? bigfloat)
   (equal? bigfloat '+nan.bf))
 
 (define (bf-list->bf bf-list)
   (cond
-    [(is-nan? bf-list)
-     +nan.bf]
-    [(equal? bf-list '0.bf)
-     0.bf]
-    [(equal? bf-list '-0.bf)
-     0.bf]
-    [(equal? bf-list '+inf.bf)
-     +inf.bf]
-    [(equal? bf-list '-inf.bf)
-     -inf.bf]
-    [else
-     (bf (second bf-list))]))
+    [(is-nan? bf-list) +nan.bf]
+    [(equal? bf-list '0.bf) 0.bf]
+    [(equal? bf-list '-0.bf) 0.bf]
+    [(equal? bf-list '+inf.bf) +inf.bf]
+    [(equal? bf-list '-inf.bf) -inf.bf]
+    [else (bf (second bf-list))]))
 
 (define (mathematica-domain-error? point-str)
   (equal? point-str "\ndomain-error\n"))
 
 (define (mathematica-number? point-str)
   (define strings (string-split point-str "\n"))
-  (cond [(equal? (length strings) 1)
-         (define parts (string-split (first strings) (regexp "(\\*\\^)|(`+)")))
-	 (and (< (length parts) 4)
-	      (andmap string->number parts))]
-	[else #f]))
-      
+  (cond
+    [(equal? (length strings) 1)
+     (define parts (string-split (first strings) (regexp "(\\*\\^)|(`+)")))
+     (and (< (length parts) 4) (andmap string->number parts))]
+    [else #f]))
 
 (define unsamplable-set
-	(set "Underflow[]" "Overflow[]" "domain-error" "warning" "Indeterminate" "ComplexInfinity"))
-(define samplable-set
-	(set "True" "False"))
+  (set "Underflow[]" "Overflow[]" "domain-error" "warning" "Indeterminate" "ComplexInfinity"))
+(define samplable-set (set "True" "False"))
 
 (define (mathematica-samplable? point-str)
-	(cond
-		[(set-member? unsamplable-set (string-trim point-str))
-		 #f]
-		[(or (set-member? samplable-set (string-trim point-str)) (mathematica-number? point-str))
-		 #t]
-		[else
-		 (error 'unrecognized-mathematica-output point-str)]))		
-
+  (cond
+    [(set-member? unsamplable-set (string-trim point-str)) #f]
+    [(or (set-member? samplable-set (string-trim point-str)) (mathematica-number? point-str)) #t]
+    [else (error 'unrecognized-mathematica-output point-str)]))
 
 (define (is-immovable? rival-res)
   (define left-e (vector-ref rival-res 1))
@@ -80,64 +76,76 @@
   (define left-i (vector-ref left-e 2))
   (define right-i (vector-ref right-e 2))
   (or (and left-i right-i) (and (bfinfinite? left-val) left-i) (and (bfinfinite? right-val) right-i)))
-  
 
 (define (collect-mathematica port rival-port bench-to-mdata sofar examples-port)
   (define read-res (read port))
 
   (when (equal? (modulo sofar 1000) 0)
-        (printf "Processed ~a points\n" sofar))
-  
+    (printf "Processed ~a points\n" sofar))
+
   (cond
     [(not (equal? read-res eof))
      (match-define (list suite prog pt rival-res) (read rival-port))
      (define mathematica-point read-res)
 
      (when (not (hash-has-key? bench-to-mdata suite))
-           (hash-set! bench-to-mdata suite (mdata (make-hash (list (cons 't 0) (cons 'f 0) (cons 'o 0)))
-                                                  0 0 0 0 0 0)))
+       (hash-set! bench-to-mdata
+                  suite
+                  (mdata (make-hash (list (cons 't 0) (cons 'f 0) (cons 'o 0))) 0 0 0 0 0 0)))
      (define data (hash-ref bench-to-mdata suite))
      (define rival-hash (mdata-rival-error-hash data))
 
      (cond
-       [(equal? (vector-ref rival-res 4) #t)
-        (hash-update! rival-hash 't (lambda (a) (+ a 1)))]
-       [(equal? (vector-ref rival-res 3) #f)
-        (hash-update! rival-hash 'f (lambda (a) (+ a 1)))]
-       [else
-        (hash-update! rival-hash 'o (lambda (a) (+ a 1)))])
+       [(equal? (vector-ref rival-res 4) #t) (hash-update! rival-hash 't (lambda (a) (+ a 1)))]
+       [(equal? (vector-ref rival-res 3) #f) (hash-update! rival-hash 'f (lambda (a) (+ a 1)))]
+       [else (hash-update! rival-hash 'o (lambda (a) (+ a 1)))])
 
      (define rival-no-error (equal? (vector-ref rival-res 3) #f))
-     
+
      (define is-samplable (and rival-no-error (samplable? (get-low rival-res) (get-hi rival-res))))
      (define is-immovable (and (not is-samplable) (is-immovable? rival-res)))
 
-     (match-define (mdata rival-error-hash rival-samplable rival-movability rival-possible mathematica-samplable mathematica-unsamplable mathematica-error) data)
+     (match-define (mdata rival-error-hash
+                          rival-samplable
+                          rival-movability
+                          rival-possible
+                          mathematica-samplable
+                          mathematica-unsamplable
+                          mathematica-error)
+       data)
 
      (define m-samplable? (mathematica-samplable? mathematica-point))
      (define m-error? (mathematica-domain-error? mathematica-point))
 
      (when (and m-samplable? (not is-samplable))
-           (writeln (list suite prog pt (list "rival" "samplable:" is-samplable "error:" (not rival-no-error) "immovable:" is-immovable)
-                                        (list "mathematica:" "samplable:" m-samplable? "error:" m-error?)) examples-port))
-	   
+       (writeln (list suite
+                      prog
+                      pt
+                      (list "rival"
+                            "samplable:"
+                            is-samplable
+                            "error:"
+                            (not rival-no-error)
+                            "immovable:"
+                            is-immovable)
+                      (list "mathematica:" "samplable:" m-samplable? "error:" m-error?))
+                examples-port))
+
      (define new-data
-       (struct-copy mdata data
-                          [rival-samplable (if is-samplable (+ rival-samplable 1) rival-samplable)]
-			  [rival-movability (if (and rival-no-error is-immovable) (+ rival-movability 1) rival-movability)]
-			  [rival-possible (if (and rival-no-error (not is-samplable) (not is-immovable))
-			                      (+ rival-possible 1) rival-possible)]
-			  [mathematica-samplable (if m-samplable?
-			                             (+ mathematica-samplable 1) mathematica-samplable)]
-			  [mathematica-unsamplable (if (not m-samplable?)
-			                               (+ mathematica-unsamplable 1)
-						       mathematica-unsamplable)]
-		    [mathematica-error (if m-error? (+ mathematica-error 1) mathematica-error)]))
+       (struct-copy mdata
+                    data
+                    [rival-samplable (if is-samplable (+ rival-samplable 1) rival-samplable)]
+                    [rival-movability
+                     (if (and rival-no-error is-immovable) (+ rival-movability 1) rival-movability)]
+                    [rival-possible
+                     (if (and rival-no-error (not is-samplable) (not is-immovable))
+                         (+ rival-possible 1)
+                         rival-possible)]
+                    [mathematica-samplable
+                     (if m-samplable? (+ mathematica-samplable 1) mathematica-samplable)]
+                    [mathematica-unsamplable
+                     (if (not m-samplable?) (+ mathematica-unsamplable 1) mathematica-unsamplable)]
+                    [mathematica-error (if m-error? (+ mathematica-error 1) mathematica-error)]))
      (hash-set! bench-to-mdata suite new-data)
-     (collect-mathematica port
-		    rival-port
-        bench-to-mdata
-        (+ sofar 1)
-        examples-port)]
-    [else
-     bench-to-mdata]))
+     (collect-mathematica port rival-port bench-to-mdata (+ sofar 1) examples-port)]
+    [else bench-to-mdata]))

--- a/infra/generate-points.rkt
+++ b/infra/generate-points.rkt
@@ -1,12 +1,12 @@
 #lang racket
 (require (only-in fpbench interval range-table-ref condition->range-table [expr? fpcore-expr?]))
-(require math/base math/flonum)
+(require math/base
+         math/flonum)
 
 (define (replace-vars dict expr)
   (cond
     [(dict-has-key? dict expr) (dict-ref dict expr)]
-    [(list? expr)
-     (cons (replace-vars dict (car expr)) (map (curry replace-vars dict) (cdr expr)))]
+    [(list? expr) (cons (replace-vars dict (car expr)) (map (curry replace-vars dict) (cdr expr)))]
     [#t expr]))
 
 (define (unfold-let expr)
@@ -14,36 +14,30 @@
     [`(let ([,vars ,vals] ...) ,body)
      (define bindings (map cons vars (map unfold-let vals)))
      (replace-vars bindings (unfold-let body))]
-    [`(let* () ,body)
-     (unfold-let body)]
+    [`(let* () ,body) (unfold-let body)]
     [`(let* ([,var ,val] ,rest ...) ,body)
      (replace-vars (list (cons var (unfold-let val))) (unfold-let `(let* ,rest ,body)))]
-    [`(,head ,args ...)
-     (cons head (map unfold-let args))]
+    [`(,head ,args ...) (cons head (map unfold-let args))]
     [x x]))
 
 (define (expand-associativity expr)
   (match expr
     [(list (and (or '+ '- '* '/) op) a ..2 b)
-     (list op
-           (expand-associativity (cons op a))
-           (expand-associativity b))]
+     (list op (expand-associativity (cons op a)) (expand-associativity b))]
     [(list (or '+ '*) a) (expand-associativity a)]
     [(list '- a) (list 'neg (expand-associativity a))]
     [(list '/ a) (list '/ 1 (expand-associativity a))]
     [(list (or '+ '-)) 0]
     [(list (or '* '/)) 1]
-    [(list op a ...)
-     (cons op (map expand-associativity a))]
-    [_
-     expr]))
+    [(list op a ...) (cons op (map expand-associativity a))]
+    [_ expr]))
 
 (define (desugar expr)
   (expand-associativity (unfold-let expr)))
 
 (define (parse-test stx)
   (match-define (list 'FPCore (? symbol?) ... (list args ...) props ... body) (syntax->datum stx))
-  
+
   (define prop-dict
     (let loop ([props props])
       (match props
@@ -52,13 +46,13 @@
 
   (list (dict-ref prop-dict ':pre 'TRUE) `(λ ,args ,(desugar body))))
 
-
 (define (load-file file)
   (call-with-input-file file
-    (λ (port)
-      (for/list ([test (in-port (curry read-syntax file) port)])
-        (define name (path->string (file-name-from-path (path-replace-extension file ""))))
-        (cons name (parse-test test))))))
+                        (λ (port)
+                          (for/list ([test (in-port (curry read-syntax file) port)])
+                            (define name
+                              (path->string (file-name-from-path (path-replace-extension file ""))))
+                            (cons name (parse-test test))))))
 
 (define (load-directory dir)
   (define-values (_u basename _un) (split-path dir))
@@ -67,8 +61,8 @@
          (for/list ([fname (in-directory dir)]
                     #:when (file-exists? fname)
                     #:when (equal? (filename-extension fname) #"fpcore"))
-             (for/list ([result (load-file fname)])
-                 (cons suite-name (rest result))))))
+           (for/list ([result (load-file fname)])
+             (cons suite-name (rest result))))))
 
 (define (load-tests path)
   (define path* (if (string? path) (string->path path) path))
@@ -76,11 +70,9 @@
          (for/list ([fname (directory-list path* #:build? true)]
                     #:when (or (directory-exists? fname)
                                (equal? (filename-extension fname) #"fpcore")))
-            (cond
-                [(directory-exists? fname)
-                    (load-directory fname)]
-                [else
-                    (load-file fname)]))))
+           (cond
+             [(directory-exists? fname) (load-directory fname)]
+             [else (load-file fname)]))))
 
 (define (program-variables prog)
   (match-define (list (or 'lambda 'λ 'FPCore) (list vars ...) body) prog)
@@ -89,21 +81,20 @@
 (define (sample-points variables precondition number)
   (define range-table (condition->range-table precondition))
   (for/list ([i (in-range number)])
-      (for/list ([var variables])
-          (match-define (interval lo hi lo? hi?) (first (range-table-ref range-table var)))
-          (ordinal->flonum (random-integer (flonum->ordinal (real->double-flonum lo))
-                                           (+ 1 (flonum->ordinal (real->double-flonum hi))))))))
-  
+    (for/list ([var variables])
+      (match-define (interval lo hi lo? hi?) (first (range-table-ref range-table var)))
+      (ordinal->flonum (random-integer (flonum->ordinal (real->double-flonum lo))
+                                       (+ 1 (flonum->ordinal (real->double-flonum hi))))))))
 
 (define (make-points tests output-file)
   (for ([test tests])
-       (match-define (list benchname precondition program) test)
-       (define points (sample-points (program-variables program) precondition 256))
-       (for ([point points])
-            (writeln (list benchname program point) output-file))))
-
+    (match-define (list benchname precondition program) test)
+    (define points (sample-points (program-variables program) precondition 256))
+    (for ([point points])
+      (writeln (list benchname program point) output-file))))
 
 (module+ main
-   (command-line #:program "generate-points"
-      #:args (benchmarks-dir output-file)
-      (make-points (load-tests benchmarks-dir) (open-output-file output-file #:exists 'replace))))
+  (command-line #:program "generate-points"
+                #:args (benchmarks-dir output-file)
+                (make-points (load-tests benchmarks-dir)
+                             (open-output-file output-file #:exists 'replace))))

--- a/infra/interval-evaluate.rkt
+++ b/infra/interval-evaluate.rkt
@@ -1,103 +1,92 @@
 #lang racket
 
 (require math/bigfloat)
-(require "../main.rkt" biginterval)
+(require "../main.rkt"
+         biginterval)
 
 (provide interval-evaluate)
 
 (define all-constants
   `((PI ,ival-pi ,(lambda () (iv pi.bf pi.bf)))
     (E ,ival-e ,(λ () (iv (bfexp 1.bf) (bfexp 1.bf))))
-    (INFINITY ,(λ () (mk-ival +inf.bf))
-              ,(λ () (iv +inf.bf +inf.bf)))
-    (NAN ,(λ () (mk-ival +nan.bf))
-         ,(λ () (iv +nan.bf +nan.bf)))
+    (INFINITY ,(λ () (mk-ival +inf.bf)) ,(λ () (iv +inf.bf +inf.bf)))
+    (NAN ,(λ () (mk-ival +nan.bf)) ,(λ () (iv +nan.bf +nan.bf)))
     (TRUE ,(λ () (ival-bool true)) #f)
     (FALSE ,(λ () (ival-bool false)) #f)))
 
 (define all-ops
-  `((+ ,ival-add ,ivadd)
-     (- ,ival-sub ,ivsub)
-     (neg ,ival-neg ,ivneg)
-     (* ,ival-mult ,ivmul)
-     (/ ,ival-div ,ivdiv)
-     (acos ,ival-acos ,ivacos)
-     (acosh ,ival-acosh ,ivacosh)
-     (asin ,ival-asin ,ivasin)
-     (asinh ,ival-asinh ,ivasinh)
-     (atan ,ival-atan ,ivatan)
-     (atan2 ,ival-atan2 ,ivatan2)
-     (atanh ,ival-atanh ,ivatanh)
-     (cbrt ,ival-cbrt ,ivcbrt)
-     (ceil ,ival-ceil #f)
-     (copysign ,ival-copysign #f)
-     (cos ,ival-cos ,ivcos)
-     (cosh ,ival-cosh ,ivcosh)
-     (erf ,ival-erf #f)
-     (erfc ,ival-erfc #f)
-     (exp ,ival-exp ,ivexp)
-     (exp2  ,ival-exp2 ,ivexp2)
-     (expm1 ,ival-expm1 ,ivexpm1)
-     (fabs ,ival-fabs ,ivfabs)
-     (fdim ,ival-fdim #f)
-     (floor ,ival-floor #f)
-     (fma ,ival-fma #f)
-     (fmax ,ival-fmax #f)
-     (fmin ,ival-fmin #f)
-     (fmod ,ival-fmod #f)
-     (hypot ,ival-hypot ,ivhypot)
-     (log ,ival-log ,ivlog)
-     (log10 ,ival-log10 ,ivlog10)
-     (log1p ,ival-log1p ,ivlog1p)
-     (log2 ,ival-log2 ,ivlog2)
-     (logb ,ival-logb #f)
-     (pow ,ival-pow #f)
-     (remainder ,ival-remainder #f)
-     (rint ,ival-rint #f)
-     (round ,ival-round #f)
-     (sin ,ival-sin ,ivsin)
-     (sinh ,ival-sinh ,ivsinh)
-     (sqrt ,ival-sqrt ,ivsqrt)
-     (tan ,ival-tan ,ivtan)
-     (tanh ,ival-tanh ,ivtanh)
-     (trunc ,ival-trunc #f)
-     (if ,ival-if #f)
-     (== ,ival-== #f)
-     (!= ,ival-!= #f)
-     (< ,ival-< #f)
-     (> ,ival-> #f)
-     (<= ,ival-<= #f)
-     (>= ,ival->= #f)
-     (not ,ival-not #f)
-     (and ,ival-and #f)
-     (or ,ival-or #f)))
+  `((+ ,ival-add ,ivadd) (- ,ival-sub ,ivsub)
+                         (neg ,ival-neg ,ivneg)
+                         (* ,ival-mult ,ivmul)
+                         (/ ,ival-div ,ivdiv)
+                         (acos ,ival-acos ,ivacos)
+                         (acosh ,ival-acosh ,ivacosh)
+                         (asin ,ival-asin ,ivasin)
+                         (asinh ,ival-asinh ,ivasinh)
+                         (atan ,ival-atan ,ivatan)
+                         (atan2 ,ival-atan2 ,ivatan2)
+                         (atanh ,ival-atanh ,ivatanh)
+                         (cbrt ,ival-cbrt ,ivcbrt)
+                         (ceil ,ival-ceil #f)
+                         (copysign ,ival-copysign #f)
+                         (cos ,ival-cos ,ivcos)
+                         (cosh ,ival-cosh ,ivcosh)
+                         (erf ,ival-erf #f)
+                         (erfc ,ival-erfc #f)
+                         (exp ,ival-exp ,ivexp)
+                         (exp2 ,ival-exp2 ,ivexp2)
+                         (expm1 ,ival-expm1 ,ivexpm1)
+                         (fabs ,ival-fabs ,ivfabs)
+                         (fdim ,ival-fdim #f)
+                         (floor ,ival-floor #f)
+                         (fma ,ival-fma #f)
+                         (fmax ,ival-fmax #f)
+                         (fmin ,ival-fmin #f)
+                         (fmod ,ival-fmod #f)
+                         (hypot ,ival-hypot ,ivhypot)
+                         (log ,ival-log ,ivlog)
+                         (log10 ,ival-log10 ,ivlog10)
+                         (log1p ,ival-log1p ,ivlog1p)
+                         (log2 ,ival-log2 ,ivlog2)
+                         (logb ,ival-logb #f)
+                         (pow ,ival-pow #f)
+                         (remainder ,ival-remainder #f)
+                         (rint ,ival-rint #f)
+                         (round ,ival-round #f)
+                         (sin ,ival-sin ,ivsin)
+                         (sinh ,ival-sinh ,ivsinh)
+                         (sqrt ,ival-sqrt ,ivsqrt)
+                         (tan ,ival-tan ,ivtan)
+                         (tanh ,ival-tanh ,ivtanh)
+                         (trunc ,ival-trunc #f)
+                         (if ,ival-if #f)
+                         (== ,ival-== #f)
+                         (!= ,ival-!= #f)
+                         (< ,ival-< #f)
+                         (> ,ival-> #f)
+                         (<= ,ival-<= #f)
+                         (>= ,ival->= #f)
+                         (not ,ival-not #f)
+                         (and ,ival-and #f)
+                         (or ,ival-or #f)))
 
 (define op-table
-  (make-hash
-   (for/list ([op-list all-ops])
-             (cons (first op-list) (cons (second op-list) (third op-list))))))
+  (make-hash (for/list ([op-list all-ops])
+               (cons (first op-list) (cons (second op-list) (third op-list))))))
 
 (define constant-table
-  (make-hash
-   (for/list ([op-list all-constants])
-             (cons (first op-list) (cons (second op-list) (third op-list))))))
+  (make-hash (for/list ([op-list all-constants])
+               (cons (first op-list) (cons (second op-list) (third op-list))))))
 
 (define (convert-symbol unprocessed-symbol)
   (string->symbol (first (string-split (symbol->string unprocessed-symbol) "."))))
 
 (define (get-ival-from-table table symbol use-mpfi?)
   (cond
-    [(not (hash-has-key? table symbol))
-     (error (format "Didn't find in table ~a" symbol))]
-    [(and use-mpfi? (cdr (hash-ref table symbol)))
-     (cdr (hash-ref table symbol))]
-    [(and (not use-mpfi?) (car (hash-ref table symbol)))
-     (car (hash-ref table symbol))]
-    [else
-     (lambda xs #f)]))
-     
-    
-
+    [(not (hash-has-key? table symbol)) (error (format "Didn't find in table ~a" symbol))]
+    [(and use-mpfi? (cdr (hash-ref table symbol))) (cdr (hash-ref table symbol))]
+    [(and (not use-mpfi?) (car (hash-ref table symbol))) (car (hash-ref table symbol))]
+    [else (lambda xs #f)]))
 
 (define (convert-number expression use-mpfi?)
   (if use-mpfi? (iv expression) (mk-ival (bf expression))))
@@ -105,17 +94,14 @@
 (define (interval-evaluate expression variables point use-mpfi?)
   (cond
     [(list? expression)
-     (define children (map (lambda (exp) (interval-evaluate exp variables point use-mpfi?))
-                           (rest expression)))
+     (define children
+       (map (lambda (exp) (interval-evaluate exp variables point use-mpfi?)) (rest expression)))
      (if (andmap identity children)
          (apply (get-ival-from-table op-table (first expression) use-mpfi?) children)
          #f)]
     [(member expression variables)
      (convert-number (list-ref point (index-of variables expression)) use-mpfi?)]
-    [(number? expression)
-     (convert-number expression use-mpfi?)]
+    [(number? expression) (convert-number expression use-mpfi?)]
     [(get-ival-from-table constant-table expression use-mpfi?)
      ((get-ival-from-table constant-table expression use-mpfi?))]
-    [else
-     (error (format "Undefined symbol ~a" expression))]))
-     
+    [else (error (format "Undefined symbol ~a" expression))]))

--- a/infra/report.rkt
+++ b/infra/report.rkt
@@ -1,7 +1,8 @@
 #lang racket
 
-(require math/bigfloat xml racket/date)
-
+(require math/bigfloat
+         xml
+         racket/date)
 
 (require biginterval)
 (require "../main.rkt")
@@ -16,71 +17,55 @@
   (bf-list->bf (second mpfi)))
 
 (define (sum-benches bench-to accessor)
-  (for/sum ([suite (hash-keys bench-to)])
-    (accessor (hash-ref bench-to suite))))
+  (for/sum ([suite (hash-keys bench-to)]) (accessor (hash-ref bench-to suite))))
 
 (define (get-substrings-divisible str n)
   (cond
-    [(equal? (string-length str) n)
-     (list str)]
-    [else
-      (cons (substring str 0 n) (get-substrings-divisible (substring str n) n))]))
+    [(equal? (string-length str) n) (list str)]
+    [else (cons (substring str 0 n) (get-substrings-divisible (substring str n) n))]))
 
 (define (get-substrings str n)
   (define head (substring str 0 (modulo (string-length str) n)))
   (define tail (substring str (modulo (string-length str) n)))
   (cond
-    [(equal? (string-length tail) 0)
-     (list head)]
-    [(equal? (string-length head) 0)
-     (get-substrings-divisible tail n)]
-    [else
-     (cons head (get-substrings-divisible tail n))]))
-     
+    [(equal? (string-length tail) 0) (list head)]
+    [(equal? (string-length head) 0) (get-substrings-divisible tail n)]
+    [else (cons head (get-substrings-divisible tail n))]))
 
 (define (insert-thinspaces string space)
   (string-join (get-substrings string 3) space))
 
 (define (latex-format-item item)
   (cond
-    [(exact-integer? item)
-     (insert-thinspaces (format "~a" item) "\\thinspace")]
+    [(exact-integer? item) (insert-thinspaces (format "~a" item) "\\thinspace")]
     [else (format "~a" item)]))
 
 (define (html-format-number item)
   (insert-thinspaces (~a item) "\u2009"))
 
 (define (latex-format-label label)
-  (string-replace 
-   (string-replace label "MAYBE" "$[\\bot, \\top]$")
-   "YES" "[\\top, \\top]"))
+  (string-replace (string-replace label "MAYBE" "$[\\bot, \\top]$") "YES" "[\\top, \\top]"))
 
 (define (html-format-label label)
-  (string-replace 
-   (string-replace label "MAYBE" "[\u22a5, \u22a4]")
-   "YES" "[\u22a4, \u22a4]"))
+  (string-replace (string-replace label "MAYBE" "[\u22a5, \u22a4]") "YES" "[\u22a4, \u22a4]"))
 
 (define (max-num data)
-  (apply max
-    (map (lambda (d) (if (number? d) d -inf.0)) data)))
+  (apply max (map (lambda (d) (if (number? d) d -inf.0)) data)))
 
 (define (min-num data)
-  (apply min
-    (map (lambda (d) (if (number? d) d +inf.0)) data)))
-
+  (apply min (map (lambda (d) (if (number? d) d +inf.0)) data)))
 
 (define (get-bold-index data good)
   (define processed (map (lambda (d) (if (number? d) (exact->inexact d) d)) data))
   (cond
-    [(equal? good 'none)
-     (length processed)]
+    [(equal? good 'none) (length processed)]
     [(or (equal? good 'min) (equal? good 'max))
      (define best ((if (equal? good 'max) max-num min-num) processed))
      (define after (member best processed))
-     
+
      (if (and (not (equal? #f after)) (equal? #f (member best (rest after))))
          (index-of processed best)
-	 (length processed))]))
+         (length processed))]))
 
 (define (make-latex-bold str)
   (string-append "\\textbf{" str "}"))
@@ -89,9 +74,8 @@
   (define bold-index (get-bold-index data good))
   (define strings (map latex-format-item data))
   (define-values (before after) (split-at strings bold-index))
-  (define modified-after (if (> (length after) 0)
-                             (cons (make-latex-bold (first after)) (rest after))
-			     empty))
+  (define modified-after
+    (if (> (length after) 0) (cons (make-latex-bold (first after)) (rest after)) empty))
   (append before modified-after))
 
 (define (make-latex-row data #:good [good 'none])
@@ -102,7 +86,9 @@
 
 (define (make-html-row data #:good [good 'none])
   (match-define (list label elts ...) data)
-  `(tr (th ,(html-format-label label)) ,@(for/list ([elt elts]) `(td ,(html-format-number elt)))))
+  `(tr (th ,(html-format-label label))
+       ,@(for/list ([elt elts])
+           `(td ,(html-format-number elt)))))
 
 (define (make-both-row port data #:good [good 'none])
   (displayln (make-latex-row data #:good good) port)
@@ -112,129 +98,105 @@
   ;;(displayln "\\begin{tabular}{r|rrrr}" output-port)
 
   (define total-points
-          (+ (sum-benches bench-to-mdata mdata-mathematica-unsamplable)
-	     (sum-benches bench-to-mdata mdata-mathematica-samplable)))
+    (+ (sum-benches bench-to-mdata mdata-mathematica-unsamplable)
+       (sum-benches bench-to-mdata mdata-mathematica-samplable)))
   (define mpfi-supported
-          (+ (sum-benches bench-to-idata (lambda (d) (hash-ref (idata-mpfi-error-hash d) 'f)))
-	     (sum-benches bench-to-idata (lambda (d) (hash-ref (idata-mpfi-error-hash d) 'o)))))
+    (+ (sum-benches bench-to-idata (lambda (d) (hash-ref (idata-mpfi-error-hash d) 'f)))
+       (sum-benches bench-to-idata (lambda (d) (hash-ref (idata-mpfi-error-hash d) 'o)))))
 
-  (define rival-invalid-guarantee (sum-benches bench-to-mdata (lambda (d) (hash-ref (mdata-rival-error-hash d) 't))))
-  (define rival-invalid-unsure (sum-benches bench-to-mdata (lambda (d) (hash-ref (mdata-rival-error-hash d) 'o))))
-  (define mpfi-invalid (sum-benches bench-to-idata (lambda (d) (hash-ref (idata-mpfi-error-hash d) 'o))))
-  (define mathematica-unsamplable (- (sum-benches bench-to-mdata mdata-mathematica-unsamplable) (sum-benches bench-to-mdata mdata-mathematica-error)))
+  (define rival-invalid-guarantee
+    (sum-benches bench-to-mdata (lambda (d) (hash-ref (mdata-rival-error-hash d) 't))))
+  (define rival-invalid-unsure
+    (sum-benches bench-to-mdata (lambda (d) (hash-ref (mdata-rival-error-hash d) 'o))))
+  (define mpfi-invalid
+    (sum-benches bench-to-idata (lambda (d) (hash-ref (idata-mpfi-error-hash d) 'o))))
+  (define mathematica-unsamplable
+    (- (sum-benches bench-to-mdata mdata-mathematica-unsamplable)
+       (sum-benches bench-to-mdata mdata-mathematica-error)))
   (define mathematica-invalid-guarantee (sum-benches bench-to-mdata mdata-mathematica-error))
 
   (define rival-movability-stuck (sum-benches bench-to-mdata mdata-rival-movability))
   (define rival-unsamplable-possible (sum-benches bench-to-mdata mdata-rival-possible))
-  (define mpfi-unsamplable (- mpfi-supported (sum-benches bench-to-idata idata-mpfi-samplable) mpfi-invalid))
+  (define mpfi-unsamplable
+    (- mpfi-supported (sum-benches bench-to-idata idata-mpfi-samplable) mpfi-invalid))
 
   (define rival-samplable (sum-benches bench-to-mdata mdata-rival-samplable))
   (define mathematica-samplable (sum-benches bench-to-mdata mdata-mathematica-samplable))
   (define-values (nightly-slack-process _in _out _err)
-    (subprocess #f #f #f (find-executable-path "nightly-results") "best"
+    (subprocess #f
+                #f
+                #f
+                (find-executable-path "nightly-results")
+                "best"
                 (cond
-                  [(> rival-samplable mathematica-samplable)
-                   "Rival"]
-                  [(< rival-samplable mathematica-samplable)
-                   "Mathematica"]
+                  [(> rival-samplable mathematica-samplable) "Rival"]
+                  [(< rival-samplable mathematica-samplable) "Mathematica"]
                   [else "Tied"])))
   (subprocess-wait nightly-slack-process)
-  
-  
+
   (write-xexpr
    `(html
-     (head
-      (meta ([charset "utf-8"]))
-      (link ([rel "stylesheet"] [href "index.css"]))
-      (title "Rival data for " ,(date->string (current-date))))
+     (head (meta ([charset "utf-8"]))
+           (link ([rel "stylesheet"] [href "index.css"]))
+           (title "Rival data for " ,(date->string (current-date))))
      (body
-      (h1  "Rival data for " ,(date->string (current-date)))
+      (h1 "Rival data for " ,(date->string (current-date)))
       (table
        (tr (th) (th "Rival") (th "MPFI") (th "Mathematica"))
-       ,(make-html-row (list "Samplable" rival-samplable
-                                        (sum-benches bench-to-idata idata-mpfi-samplable)
-                                        mathematica-samplable) #:good 'max)
+       ,(make-html-row (list "Samplable"
+                             rival-samplable
+                             (sum-benches bench-to-idata idata-mpfi-samplable)
+                             mathematica-samplable)
+                       #:good 'max)
+       ,(make-html-row (list "Unsupported" 0 (- total-points mpfi-supported) 0))
+       ,(make-html-row (list "Total Invalid"
+                             (+ rival-invalid-guarantee rival-invalid-unsure)
+                             mpfi-invalid
+                             mathematica-invalid-guarantee)
+                       #:good 'none)
+       ,(make-html-row (list "Invalid YES" rival-invalid-guarantee 0 mathematica-invalid-guarantee)
+                       #:good 'max)
+       ,(make-html-row (list "Invalid MAYBE" rival-invalid-unsure mpfi-invalid 0) #:good 'min)
+       ,(make-html-row (list "Total Stuck"
+                             (+ rival-movability-stuck rival-unsamplable-possible)
+                             mpfi-unsamplable
+                             mathematica-unsamplable)
+                       #:good 'none)
+       ,(make-html-row (list "Stuck YES" rival-movability-stuck 0 0) #:good 'max)
        ,(make-html-row
-        (list "Unsupported"
-              0
-		          (- total-points mpfi-supported)
-		          0))
-       ,(make-html-row
-        (list "Total Invalid"
-        	     (+ rival-invalid-guarantee rival-invalid-unsure)
-		           mpfi-invalid
-		           mathematica-invalid-guarantee) #:good 'none)
+         (list "Stuck MAYBE" rival-unsamplable-possible mpfi-unsamplable mathematica-unsamplable)
+         #:good 'min))))
+   output-port)
 
-       ,(make-html-row
-               (list "Invalid YES"
-	       	     rival-invalid-guarantee
-		     0
-		     mathematica-invalid-guarantee) #:good 'max)
+  #;
+  (displayln (make-html-row
+              (list "No Error"
+                    (sum-benches bench-to-mdata (lambda (d) (hash-ref (mdata-rival-error-hash d) 'f)))
+                    (sum-benches bench-to-idata (lambda (d) (hash-ref (idata-mpfi-error-hash d) 'f)))
+                    (sum-benches bench-to-mdata mdata-mathematica-samplable)))
+             output-port))
 
-       ,(make-html-row
-                (list "Invalid MAYBE"
-		      rival-invalid-unsure
-		      mpfi-invalid
-		      0) #:good 'min)
-
-      ,(make-html-row
-       		(list "Total Stuck"
-		      (+ rival-movability-stuck rival-unsamplable-possible)
-		      mpfi-unsamplable
-		      mathematica-unsamplable) #:good 'none)
-
-      ,(make-html-row
-       		(list "Stuck YES"
-               		      rival-movability-stuck
-                       		      0
-                               		      0) #:good 'max)
-
-      ,(make-html-row
-       		(list "Stuck MAYBE"
-                               rival-unsamplable-possible
-                               mpfi-unsamplable
-                               mathematica-unsamplable) #:good 'min)
-
-      )
-     ))
-  output-port
-  )
-
-  
-
-  #;(displayln (make-html-row
-                (list "No Error"
-		(sum-benches bench-to-mdata (lambda (d) (hash-ref (mdata-rival-error-hash d) 'f)))
-		(sum-benches bench-to-idata (lambda (d) (hash-ref (idata-mpfi-error-hash d) 'f)))	
-		(sum-benches bench-to-mdata mdata-mathematica-samplable))) output-port)	     	
-)
-
-  ;(displayln "\\end{tabular}" output-port)
+;(displayln "\\end{tabular}" output-port)
 (define (is-nan? bigfloat)
   (equal? bigfloat '+nan.bf))
 
 (define (output-var name val port [comment ""])
-  (define comment-string
-    (if (equal? comment "")
-        ""
-        (format "% ~a" comment)))
+  (define comment-string (if (equal? comment "") "" (format "% ~a" comment)))
   (fprintf port "\\newcommand{\\~a}{~a\\xspace}~a\n" name val comment-string))
-
 
 (define (round1 num)
   (~r num #:precision `(= 1)))
 
 (define (output-percent proportion)
-  (format "~a\\%"
-          (round1 (* 100 proportion))))
+  (format "~a\\%" (round1 (* 100 proportion))))
 
 (define (output-examples-data examples output)
   (define total-count 0)
   (define error-count 0)
   (for ([syntax (in-port read examples)])
-       (set! total-count (+ 1 total-count))
-       (when (list-ref (list-ref syntax 3) 4)
-        (set! error-count (+ 1 error-count))))
+    (set! total-count (+ 1 total-count))
+    (when (list-ref (list-ref syntax 3) 4)
+      (set! error-count (+ 1 error-count))))
   (output-var "total-mathematica-samplable-rival-unsamplable" total-count output)
   (output-var "total-mathematica-samplable-rival-error" error-count output)
   (output-var "percent-mathematica-samplable-rival-error" (/ error-count total-count) output))
@@ -243,23 +205,27 @@
   (define read-res (read port))
 
   (when (equal? (modulo sofar 1000) 0)
-        (printf "Processed ~a MPFI points\n" sofar))
-  
+    (printf "Processed ~a MPFI points\n" sofar))
+
   (cond
     [(not (equal? read-res eof))
      (match-define (list suite prog pt rival-res mpfi-res) read-res)
 
      (when (not (hash-has-key? bench-to-idata suite))
-           (hash-set! bench-to-idata suite (idata (make-hash (list (cons 'f 0) (cons 'o 0)))
-                                                  (make-hash (list (cons 't 0) (cons 'f 0) (cons 'o 0)))
-                                                  0 0 0)))
+       (hash-set! bench-to-idata
+                  suite
+                  (idata (make-hash (list (cons 'f 0) (cons 'o 0)))
+                         (make-hash (list (cons 't 0) (cons 'f 0) (cons 'o 0)))
+                         0
+                         0
+                         0)))
      (define data (hash-ref bench-to-idata suite))
-     
+
      (define mpfi-hash (idata-mpfi-error-hash data))
      (define rival-hash (idata-rival-error-hash data))
-     
+
      (define has-nan? (or (is-nan? (first mpfi-res)) (is-nan? (second mpfi-res))))
-     
+
      (if has-nan?
          (hash-update! mpfi-hash 'o (lambda (a) (+ a 1)))
          (hash-update! mpfi-hash 'f (lambda (a) (+ a 1))))
@@ -267,45 +233,48 @@
      (define rival-no-error #f)
      (define may-error-mpfi-good (idata-may-error-mpfi-good data))
      (cond
-       [(equal? (vector-ref rival-res 4) #t)
-        (hash-update! rival-hash 't (lambda (a) (+ a 1)))]
+       [(equal? (vector-ref rival-res 4) #t) (hash-update! rival-hash 't (lambda (a) (+ a 1)))]
        [(equal? (vector-ref rival-res 3) #f)
         (set! rival-no-error #t)
         (hash-update! rival-hash 'f (lambda (a) (+ a 1)))]
        [else
         (when (not has-nan?)
-              (set! may-error-mpfi-good (+ may-error-mpfi-good 1)))
+          (set! may-error-mpfi-good (+ may-error-mpfi-good 1)))
         (hash-update! rival-hash 'o (lambda (a) (+ a 1)))])
 
      (define rival-samplable
        (if (and rival-no-error (samplable? (get-low rival-res) (get-hi rival-res)))
-          (+ (idata-rival-samplable data) 1)
-          (idata-rival-samplable data)))
+           (+ (idata-rival-samplable data) 1)
+           (idata-rival-samplable data)))
 
      (define mpfi-samplable
        (if (and (not has-nan?) (samplable? (get-mpfi-left mpfi-res) (get-mpfi-right mpfi-res)))
-          (+ (idata-mpfi-samplable data) 1)
-          (idata-mpfi-samplable data)))
+           (+ (idata-mpfi-samplable data) 1)
+           (idata-mpfi-samplable data)))
 
      (define new-data
-       (struct-copy idata data
-                                 [may-error-mpfi-good may-error-mpfi-good]
-                                 [rival-samplable rival-samplable]
-                                 [mpfi-samplable mpfi-samplable]))
+       (struct-copy idata
+                    data
+                    [may-error-mpfi-good may-error-mpfi-good]
+                    [rival-samplable rival-samplable]
+                    [mpfi-samplable mpfi-samplable]))
      (hash-set! bench-to-idata suite new-data)
-     (run-on-points port
-                    bench-to-idata
-                    (+ sofar 1))]
-    [else
-     bench-to-idata]))
+     (run-on-points port bench-to-idata (+ sofar 1))]
+    [else bench-to-idata]))
 
 (module+ main
   (command-line #:program "report"
-    #:args (mpfi-results-file mathematica-results-file rival-results-file output-file examples-file macros-file)
-    (output-data (collect-mathematica (open-input-file mathematica-results-file)
-                                      (open-input-file rival-results-file)
-                                      (make-hash) 0
-                                      (open-output-file examples-file #:exists 'replace))
-                 (run-on-points (open-input-file mpfi-results-file) (make-hash) 0)
-		 (open-output-file output-file #:exists 'replace))
-    (output-examples-data (open-input-file examples-file) (open-output-file macros-file #:exists 'replace))))
+                #:args (mpfi-results-file mathematica-results-file
+                                          rival-results-file
+                                          output-file
+                                          examples-file
+                                          macros-file)
+                (output-data (collect-mathematica (open-input-file mathematica-results-file)
+                                                  (open-input-file rival-results-file)
+                                                  (make-hash)
+                                                  0
+                                                  (open-output-file examples-file #:exists 'replace))
+                             (run-on-points (open-input-file mpfi-results-file) (make-hash) 0)
+                             (open-output-file output-file #:exists 'replace))
+                (output-examples-data (open-input-file examples-file)
+                                      (open-output-file macros-file #:exists 'replace))))

--- a/infra/run-mathematica.rkt
+++ b/infra/run-mathematica.rkt
@@ -9,59 +9,57 @@
 (require "./run-mpfi.rkt")
 
 (define function->wolfram
-  (make-hash
-    `((pow . Power)
-      (+ . Plus)
-      (- . Subtract)
-      (/ . Divide)
-      (sqrt . Sqrt)
-      (* . Times)
-      (fma . FMA)
-      (hypot . Hypot)
-      (exp . Exp)
-      (log . Log)
-      (log10 . Log10)
-      (log2 . Log2)
-      (cbrt . CubeRoot)
-      (sin . Sin)
-      (cos . Cos)
-      (tan . Tan)
-      (asin . ArcSin)
-      (acos . ArcCos)
-      (atan . ArcTan)
-      (sinh . Sinh)
-      (cosh . Cosh)
-      (tanh . Tanh)
-      (asinh . ArcSinh)
-      (acosh . ArcCosh)
-      (atanh . ArcTanh)
-      (atan2 . ArcTan)
-      (erf . Erf)
-      (erfc . Erfc)
-      (tgamma . Gamma)
-      (lgamma . LogGamma)
-      (ceil . Ceiling)
-      (floor . Floor)
-      (fmod . Mod)
-      (remainder . QuotientRemainer)
-      (fmax . Max)
-      (fmin . Min)
-      (truc . Truncate)
-      (round . Round)
-      (if . If)
-      (< . LessThan)
-      (> . GreaterThan)
-      (<= . LessEqual)
-      (>= . GreaterEqual)
-      (== . Equal)
-      (!= . NotEqual)
-      (and . And)
-      (or . Or)
-      (not . Not)
-      (neg . Minus)
-      (fabs . Abs))))
+  (make-hash `((pow . Power) (+ . Plus)
+                             (- . Subtract)
+                             (/ . Divide)
+                             (sqrt . Sqrt)
+                             (* . Times)
+                             (fma . FMA)
+                             (hypot . Hypot)
+                             (exp . Exp)
+                             (log . Log)
+                             (log10 . Log10)
+                             (log2 . Log2)
+                             (cbrt . CubeRoot)
+                             (sin . Sin)
+                             (cos . Cos)
+                             (tan . Tan)
+                             (asin . ArcSin)
+                             (acos . ArcCos)
+                             (atan . ArcTan)
+                             (sinh . Sinh)
+                             (cosh . Cosh)
+                             (tanh . Tanh)
+                             (asinh . ArcSinh)
+                             (acosh . ArcCosh)
+                             (atanh . ArcTanh)
+                             (atan2 . ArcTan)
+                             (erf . Erf)
+                             (erfc . Erfc)
+                             (tgamma . Gamma)
+                             (lgamma . LogGamma)
+                             (ceil . Ceiling)
+                             (floor . Floor)
+                             (fmod . Mod)
+                             (remainder . QuotientRemainer)
+                             (fmax . Max)
+                             (fmin . Min)
+                             (truc . Truncate)
+                             (round . Round)
+                             (if . If)
+                             (< . LessThan)
+                             (> . GreaterThan)
+                             (<= . LessEqual)
+                             (>= . GreaterEqual)
+                             (== . Equal)
+                             (!= . NotEqual)
+                             (and . And)
+                             (or . Or)
+                             (not . Not)
+                             (neg . Minus)
+                             (fabs . Abs))))
 
-;; exp2, expm1, 
+;; exp2, expm1,
 
 (define (number->wolfram num)
   (define num2 (inexact->exact num))
@@ -72,18 +70,15 @@
     [(list op (app expr->wolfram args) ...)
      (define fn (hash-ref function->wolfram op))
      (format "checkReal[~a[~a]]" fn (string-join args ", "))]
-    ['PI
-     "Pi"]
-    ['E
-     "E"]
-    [(? symbol?)
-     (regexp-replace #rx"[*._-]" (symbol->string expr) "AWeirdSymbol")]
-    [(? number?)
-     (number->wolfram expr)]))
+    ['PI "Pi"]
+    ['E "E"]
+    [(? symbol?) (regexp-replace #rx"[*._-]" (symbol->string expr) "AWeirdSymbol")]
+    [(? number?) (number->wolfram expr)]))
 
 (define (program->wolfram prog)
   (format "f[~a] := ~a\n"
-          (string-join (map (compose (curry format "~a_") expr->wolfram) (program-variables prog)) ", ")
+          (string-join (map (compose (curry format "~a_") expr->wolfram) (program-variables prog))
+                       ", ")
           (expr->wolfram (program-body prog))))
 
 (define (load-points port)
@@ -96,14 +91,14 @@
 (define math-path (find-executable-path "math"))
 
 (define (make-mathematica prog #:backup [backup #f])
-  (define-values (process m-out m-in m-err)
-    (subprocess #f #f #f math-path))
+  (define-values (process m-out m-in m-err) (subprocess #f #f #f math-path))
 
   (define buffer (make-bytes 65536 0))
 
   (define (ffprintf fmt . vs)
     (apply fprintf m-in fmt vs)
-    (when backup (apply fprintf backup fmt vs))
+    (when backup
+      (apply fprintf backup fmt vs))
     (flush-output m-in))
 
   (ffprintf "~a\n" (call-with-input-file "headers.wls" port->string))
@@ -119,13 +114,13 @@
   (values process m-out m-in m-err))
 
 (define (run-mathematica prog pts #:backup [backup #f])
-  (define-values (process m-out m-in m-err)
-    (make-mathematica prog #:backup backup))
+  (define-values (process m-out m-in m-err) (make-mathematica prog #:backup backup))
 
   (define buffer (make-bytes 65536 0))
   (define (ffprintf fmt . vs)
     (apply fprintf m-in fmt vs)
-    (when backup (apply fprintf backup fmt vs))
+    (when backup
+      (apply fprintf backup fmt vs))
     (flush-output m-in))
 
   (define out
@@ -137,24 +132,22 @@
         (define step (read-bytes-avail!* buffer m-out i))
         (define s (bytes->string/latin-1 buffer #f 0 (+ i step)))
         (cond
-         [(> (- (current-inexact-milliseconds) start) 2000.0)
-          (eprintf "Killing and restarting Mathematica\n")
-          (eprintf "~s\n" s)
-          (define-values (process2 m-out2 m-in2 m-err2)
-            (make-mathematica prog #:backup backup))
-          (subprocess-kill process true)
-          (set! process process2)
-          (set! m-out m-out2)
-          (set! m-in m-in2)
-          (set! m-err m-err2)
-          (cons 10000.0 'timeout)]
-         [(string-contains? s "\nIn")
-          (let ([dt (- (current-inexact-milliseconds) start)])
-            (printf ".")
-            (flush-output)
-            (cons dt (parse-output s)))]
-         [else
-          (loop (+ i step))]))))
+          [(> (- (current-inexact-milliseconds) start) 2000.0)
+           (eprintf "Killing and restarting Mathematica\n")
+           (eprintf "~s\n" s)
+           (define-values (process2 m-out2 m-in2 m-err2) (make-mathematica prog #:backup backup))
+           (subprocess-kill process true)
+           (set! process process2)
+           (set! m-out m-out2)
+           (set! m-in m-in2)
+           (set! m-err m-err2)
+           (cons 10000.0 'timeout)]
+          [(string-contains? s "\nIn")
+           (let ([dt (- (current-inexact-milliseconds) start)])
+             (printf ".")
+             (flush-output)
+             (cons dt (parse-output s)))]
+          [else (loop (+ i step))]))))
   (ffprintf "Exit[]\n")
   (subprocess-wait process)
   (cons (subprocess-status process) out))
@@ -162,97 +155,43 @@
 (define (parse-output s)
   (define lines (string-split s "\n" #:repeat? #t))
   (with-handlers ([exn:misc:match? (λ (e)
-    (newline)
-    (printf "Could not parse results:\n")
-    (pretty-print lines)
-    (exit))])
+                                     (newline)
+                                     (printf "Could not parse results:\n")
+                                     (pretty-print lines)
+                                     (exit))])
 
     (match-lines lines)))
 
 (define (match-lines lines)
   (match lines
-    [(list
-      (regexp #rx"In\\[[0-9]+\\]:= ")
-      rest ...)
-     (match-lines rest)]
-    [(list
-      rest ...
-      (regexp #rx"In\\[[0-9]+\\]:= "))
-     (match-lines rest)]
-    [(list (regexp #rx"Out\\[[0-9]+\\]= \\$Aborted"))
-     'timeout]
-    [(list (regexp #rx"Out\\[[0-9]+\\]//FullForm= (.+)" (list _ x)))
-     x]
-    [(list
-      (regexp #rx"Out\\[[0-9]+\\]//FullForm= ")
-      " "
-      (regexp #rx"> +[0-9-](.+)" (list _ x)))
-     x]
-    [(list
-      "Throw::nocatch: Uncaught Throw[domain-error, BadValue] returned to top level."
-      _ ...)
+    [(list (regexp #rx"In\\[[0-9]+\\]:= ") rest ...) (match-lines rest)]
+    [(list rest ... (regexp #rx"In\\[[0-9]+\\]:= ")) (match-lines rest)]
+    [(list (regexp #rx"Out\\[[0-9]+\\]= \\$Aborted")) 'timeout]
+    [(list (regexp #rx"Out\\[[0-9]+\\]//FullForm= (.+)" (list _ x))) x]
+    [(list (regexp #rx"Out\\[[0-9]+\\]//FullForm= ") " " (regexp #rx"> +[0-9-](.+)" (list _ x))) x]
+    [(list "Throw::nocatch: Uncaught Throw[domain-error, BadValue] returned to top level." _ ...)
      'invalid]
-    [(list
-      "General::ovfl: Overflow occurred in computation."
-      _ ...)
-     'unsamplable]
-    [(list
-      "General::unfl: Underflow occurred in computation."
-      _ ...)
-     'unsamplable]
-    [(list
-      "General::nomem: "
-      "   The current computation was aborted because there was insufficient memory"
-      "    available to complete the computation."
-      _ ...)
+    [(list "General::ovfl: Overflow occurred in computation." _ ...) 'unsamplable]
+    [(list "General::unfl: Underflow occurred in computation." _ ...) 'unsamplable]
+    [(list "General::nomem: "
+           "   The current computation was aborted because there was insufficient memory"
+           "    available to complete the computation."
+           _ ...)
      (eprintf "Mathematica ran out of memory!\n")
      'memory]
-    [(list
-      _ ...
-      (regexp #rx"Divide::indet: Indeterminate expression .*")
-      _ ...)
+    [(list _ ... (regexp #rx"Divide::indet: Indeterminate expression .*") _ ...) 'unsamplable]
+    [(list _ ... (regexp #rx"Divide::infy: Infinite expression .*") _ ...) 'unsamplable]
+    [(list "Divide::infy: Infinite expression " _ ...) 'unsamplable]
+    [(list _ ... (regexp #rx"Power::infy: Infinite expression .*") _ ...) 'unsamplable]
+    [(list _ ... (regexp #rx"Infinity::indet: Indeterminate expression .*") _ ...) 'unsamplable]
+    [(list _ ... "Infinity::indet: " _ ... (regexp #rx"Indeterminate expression .*") _ ...)
      'unsamplable]
-    [(list
-      _ ...
-      (regexp #rx"Divide::infy: Infinite expression .*")
-      _ ...)
+    [(list _ ... (regexp #rx"ArcTan::indet: Indeterminate expression .*") _ ...) 'unsamplable]
+    [(list (regexp #rx"General::stop: Further output of .*")
+           (regexp #rx" +will be suppressed during this calculation")
+           _ ...)
      'unsamplable]
-    [(list
-      "Divide::infy: Infinite expression "
-      _ ...)
-     'unsamplable]
-    [(list
-      _ ...
-      (regexp #rx"Power::infy: Infinite expression .*")
-      _ ...)
-     'unsamplable]
-    [(list
-      _ ...
-      (regexp #rx"Infinity::indet: Indeterminate expression .*")
-      _ ...)
-     'unsamplable]
-    [(list
-      _ ...
-      "Infinity::indet: "
-      _ ...
-      (regexp #rx"Indeterminate expression .*")
-      _ ...)
-     'unsamplable]
-    [(list
-      _ ...
-      (regexp #rx"ArcTan::indet: Indeterminate expression .*")
-      _ ...)
-     'unsamplable]
-    [(list
-      (regexp #rx"General::stop: Further output of .*")
-      (regexp #rx" +will be suppressed during this calculation")
-      _ ...)
-     'unsamplable]
-    [(list
-      "N::meprec: Internal precision limit $MaxExtraPrecision = 3100."
-      _ ...)
-     'unknown]
-    ))
+    [(list "N::meprec: Internal precision limit $MaxExtraPrecision = 3100." _ ...) 'unknown]))
 
 (define (count-results out)
   (define sampled 0)
@@ -263,21 +202,16 @@
   (define timeout 0)
   (for ([val out])
     (match (cdr val)
-      ['invalid
-       (set! invalid (add1 invalid))]
+      ['invalid (set! invalid (add1 invalid))]
       ['memory
        (set! unknown (add1 unknown))
        (set! crash (add1 crash))]
       ['timeout
        (set! unknown (add1 unknown))
        (set! timeout (add1 timeout))]
-      ['unsamplable
-       (set! unsamplable (add1 unsamplable))]
-      ['unknown
-       (set! unknown (add1 unknown))]
-      [(regexp #rx"[0-9]+(\\.[0-9]+)?(`[0-9]*)?(\\*\\^-?[0-9]+)?")
-       (set! sampled (add1 sampled))]
-      ))
+      ['unsamplable (set! unsamplable (add1 unsamplable))]
+      ['unknown (set! unknown (add1 unknown))]
+      [(regexp #rx"[0-9]+(\\.[0-9]+)?(`[0-9]*)?(\\*\\^-?[0-9]+)?") (set! sampled (add1 sampled))]))
   (list sampled invalid unsamplable unknown crash timeout))
 
 (define (add-results r1 r2)
@@ -286,35 +220,39 @@
 (define (print-results results)
   (match-define (list sampled invalid unsamplable unknown crash timeout) results)
   (eprintf "\nResults: ~a ok, ~a bad, ~a unsamplable, ~a unknown (~a crash, ~a timeout)\n"
-           sampled invalid unsamplable unknown crash timeout))
+           sampled
+           invalid
+           unsamplable
+           unknown
+           crash
+           timeout))
 
 (define (go points skip)
   (define results (list 0 0 0 0 0 0))
   (for ([(prog pts*) (in-hash points)])
-    (call-with-output-file "mathematica.log" #:exists 'replace
-      (λ (p)
-        (define to-drop (min skip (length pts*)))
-        (set! skip (- skip to-drop))
-        (define pts (drop pts* to-drop))
+    (call-with-output-file "mathematica.log"
+                           #:exists 'replace
+                           (λ (p)
+                             (define to-drop (min skip (length pts*)))
+                             (set! skip (- skip to-drop))
+                             (define pts (drop pts* to-drop))
 
-        (match-define (cons status out) (run-mathematica prog pts #:backup p))
-        (match status
-          [0
-           (set! results (add-results results (count-results out)))
-           (print-results results)]
-          [_
-           (printf "Status: ~a\n" status)
-           (pretty-print out)
-           (exit status)]))))
-    results)
+                             (match-define (cons status out) (run-mathematica prog pts #:backup p))
+                             (match status
+                               [0
+                                (set! results (add-results results (count-results out)))
+                                (print-results results)]
+                               [_
+                                (printf "Status: ~a\n" status)
+                                (pretty-print out)
+                                (exit status)]))))
+  results)
 
 (module+ main
   (define skip 0)
-  (command-line
-   #:program "run-mathematica"
-   #:once-each
-   [("--skip") n "How many points to skip"
-    (set! skip (or (string->number n) skip))]
-   #:args (points-file)
-   (define points (call-with-input-file points-file load-points))
-   (go points skip)))
+  (command-line #:program "run-mathematica"
+                #:once-each
+                [("--skip") n "How many points to skip" (set! skip (or (string->number n) skip))]
+                #:args (points-file)
+                (define points (call-with-input-file points-file load-points))
+                (go points skip)))

--- a/infra/run-mpfi.rkt
+++ b/infra/run-mpfi.rkt
@@ -4,7 +4,8 @@
 (require math/bigfloat)
 
 (require "./interval-evaluate.rkt")
-(provide program-body program-variables)
+(provide program-body
+         program-variables)
 
 (define (program-body prog)
   (match-define (list (or 'lambda 'λ 'FPCore) (list vars ...) body) prog)
@@ -16,28 +17,28 @@
 
 (define (run-on-points port output-port point-count)
   (parameterize ([bf-precision 10000])
-                (define read-res (read port))
-                (when (equal? (modulo point-count 1000) 0)
-                      (display "Ran on ")
-                      (display point-count)
-                      (displayln " points"))
-		(flush-output)
-  
-                (when #f #;(not (equal? read-res eof))
-                      (match-define (list suite prog pt) read-res)
-                      
-                      (define mpfi-res
-                              (interval-evaluate (program-body prog) (program-variables prog) pt #t))
+    (define read-res (read port))
+    (when (equal? (modulo point-count 1000) 0)
+      (display "Ran on ")
+      (display point-count)
+      (displayln " points"))
+    (flush-output)
 
-                      (when mpfi-res
-                            (define rival-res
-                              (interval-evaluate (program-body prog) (program-variables prog) pt #f))
-                            (writeln (list suite prog pt rival-res (list (ivleft mpfi-res) (ivright mpfi-res)))
-                                     output-port))
+    (when #f
+      #;(not (equal? read-res eof))
+      (match-define (list suite prog pt) read-res)
 
-                      (run-on-points port output-port (+ point-count 1)))))
+      (define mpfi-res (interval-evaluate (program-body prog) (program-variables prog) pt #t))
+
+      (when mpfi-res
+        (define rival-res (interval-evaluate (program-body prog) (program-variables prog) pt #f))
+        (writeln (list suite prog pt rival-res (list (ivleft mpfi-res) (ivright mpfi-res)))
+                 output-port))
+
+      (run-on-points port output-port (+ point-count 1)))))
 
 (module+ main
-  (command-line #:program "run-mpfi"
-    #:args (points-file output-file)
-    (run-on-points (open-input-file points-file) (open-output-file output-file #:exists 'replace) 0)))
+  (command-line
+   #:program "run-mpfi"
+   #:args (points-file output-file)
+   (run-on-points (open-input-file points-file) (open-output-file output-file #:exists 'replace) 0)))

--- a/main.rkt
+++ b/main.rkt
@@ -1,114 +1,119 @@
 #lang racket/base
 
-(require math/bigfloat racket/contract)
+(require math/bigfloat
+         racket/contract)
 (define value? (or/c bigfloat? boolean?))
 
 (require "ops/all.rkt")
 (define ival-list? (listof ival?))
 
-(provide ival? ival
-         (contract-out
-          [ival-lo (-> ival? value?)]
-          [ival-hi (-> ival? value?)]
-          [monotonic->ival (-> (-> value? value?) (-> ival? ival?))]
-          [comonotonic->ival (-> (-> value? value?) (-> ival? ival?))]
-          [ival-union (-> ival? ival? ival?)]
-          [ival-split (-> ival? value? (values (or/c ival? #f) (or/c ival? #f)))]
-          [close-enough->ival (-> (-> value? value? boolean?) (-> ival? ival?))])
-         (contract-out
-          [ival-pi (-> ival?)]
-          [ival-e  (-> ival?)]
-          [ival-bool (-> boolean? ival?)]
-          [ival-add (-> ival? ival? ival?)]
-          [ival-sub (-> ival? ival? ival?)]
-          [ival-neg (-> ival? ival?)]
-          [ival-mult (-> ival? ival? ival?)]
-          [ival-div (-> ival? ival? ival?)]
-          [ival-fma (-> ival? ival? ival? ival?)] ; TODO: untested
-          [ival-fabs (-> ival? ival?)]
-          [ival-sqrt (-> ival? ival?)]
-          [ival-cbrt (-> ival? ival?)]
-          [ival-hypot (-> ival? ival? ival?)]
-          [ival-exp (-> ival? ival?)]
-          [ival-exp2 (-> ival? ival?)]
-          [ival-expm1 (-> ival? ival?)]
-          [ival-log (-> ival? ival?)]
-          [ival-log2 (-> ival? ival?)]
-          [ival-log10 (-> ival? ival?)]
-          [ival-log1p (-> ival? ival?)]
-          [ival-logb (-> ival? ival?)]
-          [ival-pow (-> ival? ival? ival?)]
-          [ival-sin (-> ival? ival?)]
-          [ival-cos (-> ival? ival?)]
-          [ival-tan (-> ival? ival?)]
-          [ival-asin (-> ival? ival?)]
-          [ival-acos (-> ival? ival?)]
-          [ival-atan (-> ival? ival?)]
-          [ival-atan2 (-> ival? ival? ival?)]
-          [ival-sinh (-> ival? ival?)]
-          [ival-cosh (-> ival? ival?)]
-          [ival-tanh (-> ival? ival?)]
-          [ival-asinh (-> ival? ival?)]
-          [ival-acosh (-> ival? ival?)]
-          [ival-atanh (-> ival? ival?)]
-          [ival-erf (-> ival? ival?)]
-          [ival-erfc (-> ival? ival?)]
-          [ival-lgamma (-> ival? ival?)]
-          [ival-tgamma (-> ival? ival?)]
-          [ival-fmod (-> ival? ival? ival?)]
-          [ival-remainder (-> ival? ival? ival?)]
-          [ival-rint (-> ival? ival?)]
-          [ival-round (-> ival? ival?)]
-          [ival-ceil (-> ival? ival?)]
-          [ival-floor (-> ival? ival?)]
-          [ival-trunc (-> ival? ival?)]
-          [ival-fmin (-> ival? ival? ival?)]
-          [ival-fmax (-> ival? ival? ival?)]
-          [ival-copysign (-> ival? ival? ival?)]
-          [ival-fdim (-> ival? ival? ival?)]
-          [ival-sort (-> ival-list? (-> value? value? boolean?) ival-list?)])
-         (contract-out
-          [ival-<  (->* () #:rest (listof ival?) ival?)]
-          [ival-<= (->* () #:rest (listof ival?) ival?)]
-          [ival->  (->* () #:rest (listof ival?) ival?)]
-          [ival->= (->* () #:rest (listof ival?) ival?)]
-          [ival-== (->* () #:rest (listof ival?) ival?)]
-          [ival-!= (->* () #:rest (listof ival?) ival?)]
-          [ival-if (-> ival? ival? ival? ival?)]
-          [ival-and (->* () #:rest (listof ival?) ival?)]
-          [ival-or  (->* () #:rest (listof ival?) ival?)]
-          [ival-not (-> ival? ival?)])
-         (contract-out
-          [ival-error? (-> ival? ival?)]
-          [ival-illegal ival?]
-          [ival-assert (->* (ival?) (values) ival?)]
-          [ival-then (->* (ival?) #:rest (listof ival?) ival?)])
+(provide ival?
+         ival
+         (contract-out [ival-lo (-> ival? value?)]
+                       [ival-hi (-> ival? value?)]
+                       [monotonic->ival (-> (-> value? value?) (-> ival? ival?))]
+                       [comonotonic->ival (-> (-> value? value?) (-> ival? ival?))]
+                       [ival-union (-> ival? ival? ival?)]
+                       [ival-split (-> ival? value? (values (or/c ival? #f) (or/c ival? #f)))]
+                       [close-enough->ival (-> (-> value? value? boolean?) (-> ival? ival?))])
+         (contract-out [ival-pi (-> ival?)]
+                       [ival-e (-> ival?)]
+                       [ival-bool (-> boolean? ival?)]
+                       [ival-add (-> ival? ival? ival?)]
+                       [ival-sub (-> ival? ival? ival?)]
+                       [ival-neg (-> ival? ival?)]
+                       [ival-mult (-> ival? ival? ival?)]
+                       [ival-div (-> ival? ival? ival?)]
+                       [ival-fma (-> ival? ival? ival? ival?)] ; TODO: untested
+                       [ival-fabs (-> ival? ival?)]
+                       [ival-sqrt (-> ival? ival?)]
+                       [ival-cbrt (-> ival? ival?)]
+                       [ival-hypot (-> ival? ival? ival?)]
+                       [ival-exp (-> ival? ival?)]
+                       [ival-exp2 (-> ival? ival?)]
+                       [ival-expm1 (-> ival? ival?)]
+                       [ival-log (-> ival? ival?)]
+                       [ival-log2 (-> ival? ival?)]
+                       [ival-log10 (-> ival? ival?)]
+                       [ival-log1p (-> ival? ival?)]
+                       [ival-logb (-> ival? ival?)]
+                       [ival-pow (-> ival? ival? ival?)]
+                       [ival-sin (-> ival? ival?)]
+                       [ival-cos (-> ival? ival?)]
+                       [ival-tan (-> ival? ival?)]
+                       [ival-asin (-> ival? ival?)]
+                       [ival-acos (-> ival? ival?)]
+                       [ival-atan (-> ival? ival?)]
+                       [ival-atan2 (-> ival? ival? ival?)]
+                       [ival-sinh (-> ival? ival?)]
+                       [ival-cosh (-> ival? ival?)]
+                       [ival-tanh (-> ival? ival?)]
+                       [ival-asinh (-> ival? ival?)]
+                       [ival-acosh (-> ival? ival?)]
+                       [ival-atanh (-> ival? ival?)]
+                       [ival-erf (-> ival? ival?)]
+                       [ival-erfc (-> ival? ival?)]
+                       [ival-lgamma (-> ival? ival?)]
+                       [ival-tgamma (-> ival? ival?)]
+                       [ival-fmod (-> ival? ival? ival?)]
+                       [ival-remainder (-> ival? ival? ival?)]
+                       [ival-rint (-> ival? ival?)]
+                       [ival-round (-> ival? ival?)]
+                       [ival-ceil (-> ival? ival?)]
+                       [ival-floor (-> ival? ival?)]
+                       [ival-trunc (-> ival? ival?)]
+                       [ival-fmin (-> ival? ival? ival?)]
+                       [ival-fmax (-> ival? ival? ival?)]
+                       [ival-copysign (-> ival? ival? ival?)]
+                       [ival-fdim (-> ival? ival? ival?)]
+                       [ival-sort (-> ival-list? (-> value? value? boolean?) ival-list?)])
+         (contract-out [ival-< (->* () #:rest (listof ival?) ival?)]
+                       [ival-<= (->* () #:rest (listof ival?) ival?)]
+                       [ival-> (->* () #:rest (listof ival?) ival?)]
+                       [ival->= (->* () #:rest (listof ival?) ival?)]
+                       [ival-== (->* () #:rest (listof ival?) ival?)]
+                       [ival-!= (->* () #:rest (listof ival?) ival?)]
+                       [ival-if (-> ival? ival? ival? ival?)]
+                       [ival-and (->* () #:rest (listof ival?) ival?)]
+                       [ival-or (->* () #:rest (listof ival?) ival?)]
+                       [ival-not (-> ival? ival?)])
+         (contract-out [ival-error? (-> ival? ival?)]
+                       [ival-illegal ival?]
+                       [ival-assert (->* (ival?) (values) ival?)]
+                       [ival-then (->* (ival?) #:rest (listof ival?) ival?)])
          ; Deprecated
-         ival-lo-fixed? ival-hi-fixed? ival-err? ival-err mk-ival)
+         ival-lo-fixed?
+         ival-hi-fixed?
+         ival-err?
+         ival-err
+         mk-ival)
 
-
-(require "eval/main.rkt" (only-in "eval/machine.rkt" rival-machine?))
-(provide (contract-out
-          [rival-compile (-> (listof any/c) (listof symbol?) (listof discretization?)
-                             rival-machine?)]
-          [rival-apply (-> rival-machine? (vectorof value?) (vectorof any/c))]
-          [rival-analyze (-> rival-machine? (vectorof ival?) ival?)])
+(require "eval/main.rkt"
+         (only-in "eval/machine.rkt" rival-machine?))
+(provide (contract-out [rival-compile
+                        (-> (listof any/c) (listof symbol?) (listof discretization?) rival-machine?)]
+                       [rival-apply (-> rival-machine? (vectorof value?) (vectorof any/c))]
+                       [rival-analyze (-> rival-machine? (vectorof ival?) ival?)])
          (struct-out discretization)
-         (struct-out exn:rival) (struct-out exn:rival:invalid) (struct-out exn:rival:unsamplable)
-         *rival-max-precision* *rival-max-iterations* *rival-profile-executions*
-         *rival-use-shorthands* *rival-name-constants*
+         (struct-out exn:rival)
+         (struct-out exn:rival:invalid)
+         (struct-out exn:rival:unsamplable)
+         *rival-max-precision*
+         *rival-max-iterations*
+         *rival-profile-executions*
+         *rival-use-shorthands*
+         *rival-name-constants*
          (struct-out execution)
-         (contract-out
-          [rival-profile (-> rival-machine? symbol? any/c)]))
+         (contract-out [rival-profile (-> rival-machine? symbol? any/c)]))
 
 (require "utils.rkt")
-(provide flonum-discretization boolean-discretization bf-discretization)
+(provide flonum-discretization
+         boolean-discretization
+         bf-discretization)
 
 (module+ main
-  (require "repl.rkt" racket/cmdline)
-  (command-line
-   #:program "racket -l rival"
-   #:args ([file #f])
-   (if file
-       (call-with-input-file file rival-repl)
-       (rival-repl (current-input-port)))))
+  (require "repl.rkt"
+           racket/cmdline)
+  (command-line #:program "racket -l rival"
+                #:args ([file #f])
+                (if file (call-with-input-file file rival-repl) (rival-repl (current-input-port)))))

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -1,9 +1,19 @@
 #lang racket/base
 
-(require math/private/bigfloat/mpfr ffi/unsafe)
+(require math/private/bigfloat/mpfr
+         ffi/unsafe)
 
-(provide -inf.bf -1.bf 0.bf half.bf 1.bf 2.bf 3.bf +inf.bf +nan.bf
-         bf-return-exact? rnd)
+(provide -inf.bf
+         -1.bf
+         0.bf
+         half.bf
+         1.bf
+         2.bf
+         3.bf
+         +inf.bf
+         +nan.bf
+         bf-return-exact?
+         rnd)
 
 (define-syntax-rule (rnd mode op args ...)
   (parameterize ([bf-rounding-mode mode])
@@ -31,14 +41,16 @@
   (values out exact?))
 ;; End hairy code
 
-(define mpfr-remainder (get-mpfr-fun 'mpfr_remainder (_fun _mpfr-pointer _mpfr-pointer _mpfr-pointer _rnd_t -> _int)))
+(define mpfr-remainder
+  (get-mpfr-fun 'mpfr_remainder (_fun _mpfr-pointer _mpfr-pointer _mpfr-pointer _rnd_t -> _int)))
 
 (define (bfremainder x mod)
   (define out (bf 0))
   (mpfr-remainder out x mod (bf-rounding-mode))
   out)
 
-(define mpfr-fmod (get-mpfr-fun 'mpfr_fmod (_fun _mpfr-pointer _mpfr-pointer _mpfr-pointer _rnd_t -> _int)))
+(define mpfr-fmod
+  (get-mpfr-fun 'mpfr_fmod (_fun _mpfr-pointer _mpfr-pointer _mpfr-pointer _rnd_t -> _int)))
 
 (define (bffmod x mod)
   (define out (bf 0))
@@ -52,9 +64,12 @@
   (mpfr-log2p1 out x (bf-rounding-mode))
   out)
 
-(define mpfr-cosu (get-mpfr-fun 'mpfr_cosu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
-(define mpfr-sinu (get-mpfr-fun 'mpfr_sinu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
-(define mpfr-tanu (get-mpfr-fun 'mpfr_tanu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
+(define mpfr-cosu
+  (get-mpfr-fun 'mpfr_cosu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
+(define mpfr-sinu
+  (get-mpfr-fun 'mpfr_sinu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
+(define mpfr-tanu
+  (get-mpfr-fun 'mpfr_tanu (_fun _mpfr-pointer _mpfr-pointer _ulong _rnd_t -> _int) (lambda () #f)))
 
 (define (bfcosu n x)
   (define out (bf 0))
@@ -71,17 +86,18 @@
   (mpfr-tanu out x n (bf-rounding-mode))
   out)
 
-(unless mpfr-cosu (set! bfcosu #f))
-(unless mpfr-sinu (set! bfsinu #f))
-(unless mpfr-tanu (set! bftanu #f))
+(unless mpfr-cosu
+  (set! bfcosu #f))
+(unless mpfr-sinu
+  (set! bfsinu #f))
+(unless mpfr-tanu
+  (set! bftanu #f))
 
 (define (bflogb x)
   (bffloor (bflog2 (bfabs x))))
 
 (define (bfcopysign x y)
-  (if (bfnan? y)
-      +nan.bf
-      (bfmul (bfabs x) (if (= (bigfloat-signbit y) 1) -1.bf 1.bf))))
+  (if (bfnan? y) +nan.bf (bfmul (bfabs x) (if (= (bigfloat-signbit y) 1) -1.bf 1.bf))))
 
 (define (bffdim x y)
   (if (bfgt? x y) (bfsub x y) 0.bf))
@@ -96,20 +112,89 @@
 
 (define (bffma a b c)
   ;; `bfstep` truncates to `(bf-precision)` bits
-  (bfcopy (bfadd c (parameterize ([bf-precision (* (bf-precision) 2)]) (bfmul a b)))))
+  (bfcopy (bfadd c
+                 (parameterize ([bf-precision (* (bf-precision) 2)])
+                   (bfmul a b)))))
 
-(provide
- bf bigfloat? mpfr-sign bigfloat-exponent bigfloat-precision bf-precision mpfr-exp bf-rounding-mode
- bfpositive? bfinteger? bfzero? bfnan? bfinfinite? bfnegative? bfeven? bfodd? 
- bfcopy bfstep bigfloats-between bfprev bfnext 
- bf=? bflte? bfgte? bflt? bfgt? bfgte? 
- pi.bf bfmin2 bfmax2
- bfabs bfadd bfsub bfneg bfmul bfdiv bfremainder
- bfrint bfround bfceiling bffloor bftruncate
- bfexp bflog bfexp2 bfexpm1 bflog2 bflog1p bflog10 bfexpt 
- bfsqrt bfcbrt bfhypot 
- bfsin bfcos bftan bfsinh bfcosh bftanh bfcosu bfsinu bftanu
- bfasin bfacos bfatan bfatan2 bfasinh bfacosh bfatanh
- bflog-gamma bfgamma bferf bferfc
- bfremainder bffmod bflogb bfcopysign bffdim and-fn or-fn if-fn bffma)
-
+(provide bf
+         bigfloat?
+         mpfr-sign
+         bigfloat-exponent
+         bigfloat-precision
+         bf-precision
+         mpfr-exp
+         bf-rounding-mode
+         bfpositive?
+         bfinteger?
+         bfzero?
+         bfnan?
+         bfinfinite?
+         bfnegative?
+         bfeven?
+         bfodd?
+         bfcopy
+         bfstep
+         bigfloats-between
+         bfprev
+         bfnext
+         bf=?
+         bflte?
+         bfgte?
+         bflt?
+         bfgt?
+         bfgte?
+         pi.bf
+         bfmin2
+         bfmax2
+         bfabs
+         bfadd
+         bfsub
+         bfneg
+         bfmul
+         bfdiv
+         bfremainder
+         bfrint
+         bfround
+         bfceiling
+         bffloor
+         bftruncate
+         bfexp
+         bflog
+         bfexp2
+         bfexpm1
+         bflog2
+         bflog1p
+         bflog10
+         bfexpt
+         bfsqrt
+         bfcbrt
+         bfhypot
+         bfsin
+         bfcos
+         bftan
+         bfsinh
+         bfcosh
+         bftanh
+         bfcosu
+         bfsinu
+         bftanu
+         bfasin
+         bfacos
+         bfatan
+         bfatan2
+         bfasinh
+         bfacosh
+         bfatanh
+         bflog-gamma
+         bfgamma
+         bferf
+         bferfc
+         bfremainder
+         bffmod
+         bflogb
+         bfcopysign
+         bffdim
+         and-fn
+         or-fn
+         if-fn
+         bffma)

--- a/ops/all.rkt
+++ b/ops/all.rkt
@@ -1,20 +1,90 @@
 #lang racket
 
-(require "core.rkt" "pow.rkt" "trig.rkt" "fmod.rkt" "gamma.rkt")
+(require "core.rkt"
+         "pow.rkt"
+         "trig.rkt"
+         "fmod.rkt"
+         "gamma.rkt")
 
-(provide
- ival? (rename-out [ival-expander ival] [ival-hi-val ival-hi] [ival-lo-val ival-lo])
- ival-union ival-split monotonic->ival comonotonic->ival
- ival-illegal ival-pi ival-e ival-bool
- ival-add ival-sub ival-neg ival-mult ival-div ival-fma       
- ival-fabs ival-sqrt ival-cbrt ival-hypot ival-exp ival-exp2 ival-expm1
- ival-log ival-log2 ival-log10 ival-log1p ival-logb ival-pow ival-pow2
- ival-cos ival-sin ival-tan ival-cosu ival-sinu ival-tanu
- ival-asin ival-acos ival-atan ival-atan2 ival-sinh ival-cosh ival-tanh
- ival-asinh ival-acosh ival-atanh ival-erf ival-erfc ival-lgamma ival-tgamma    
- ival-fmod ival-remainder ival-rint ival-round ival-ceil ival-floor ival-trunc     
- ival-fmin ival-fmax ival-copysign ival-fdim ival-sort      
- ival-< ival-<= ival-> ival->= ival-== ival-!= ival-if ival-and ival-or ival-not       
- ival-error? ival-assert ival-then close-enough->ival
- ;; Deprecated
- ival-lo-fixed? ival-hi-fixed? ival-err? ival-err mk-ival)
+(provide ival?
+         (rename-out [ival-expander ival] [ival-hi-val ival-hi] [ival-lo-val ival-lo])
+         ival-union
+         ival-split
+         monotonic->ival
+         comonotonic->ival
+         ival-illegal
+         ival-pi
+         ival-e
+         ival-bool
+         ival-add
+         ival-sub
+         ival-neg
+         ival-mult
+         ival-div
+         ival-fma
+         ival-fabs
+         ival-sqrt
+         ival-cbrt
+         ival-hypot
+         ival-exp
+         ival-exp2
+         ival-expm1
+         ival-log
+         ival-log2
+         ival-log10
+         ival-log1p
+         ival-logb
+         ival-pow
+         ival-pow2
+         ival-cos
+         ival-sin
+         ival-tan
+         ival-cosu
+         ival-sinu
+         ival-tanu
+         ival-asin
+         ival-acos
+         ival-atan
+         ival-atan2
+         ival-sinh
+         ival-cosh
+         ival-tanh
+         ival-asinh
+         ival-acosh
+         ival-atanh
+         ival-erf
+         ival-erfc
+         ival-lgamma
+         ival-tgamma
+         ival-fmod
+         ival-remainder
+         ival-rint
+         ival-round
+         ival-ceil
+         ival-floor
+         ival-trunc
+         ival-fmin
+         ival-fmax
+         ival-copysign
+         ival-fdim
+         ival-sort
+         ival-<
+         ival-<=
+         ival->
+         ival->=
+         ival-==
+         ival-!=
+         ival-if
+         ival-and
+         ival-or
+         ival-not
+         ival-error?
+         ival-assert
+         ival-then
+         close-enough->ival
+         ;; Deprecated
+         ival-lo-fixed?
+         ival-hi-fixed?
+         ival-err?
+         ival-err
+         mk-ival)

--- a/ops/fmod.rkt
+++ b/ops/fmod.rkt
@@ -1,7 +1,9 @@
 #lang racket/base
 
-(require "core.rkt" "../mpfr.rkt")
-(provide ival-fmod ival-remainder)
+(require "core.rkt"
+         "../mpfr.rkt")
+(provide ival-fmod
+         ival-remainder)
 
 (define (bfmul* a b)
   (if (or (bfzero? a) (bfzero? b)) 0.bf (bfmul a b)))
@@ -9,92 +11,107 @@
 (define (ival-fmod-pos x y err? err)
   ;; Assumes both `x` and `y` are entirely positive
   (define precision (max (bf-precision) (ival-max-prec x) (ival-max-prec y)))
-  (define a (parameterize ([bf-precision precision])
-              (rnd 'down bftruncate (bfdiv (ival-lo-val x) (ival-hi-val y)))))
-  (define b (parameterize ([bf-precision precision])
-              (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y)))))
+  (define a
+    (parameterize ([bf-precision precision])
+      (rnd 'down bftruncate (bfdiv (ival-lo-val x) (ival-hi-val y)))))
+  (define b
+    (parameterize ([bf-precision precision])
+      (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y)))))
   (cond
-   [(bf=? a b) ; No intersection along `y.hi` edge
-    (define c (parameterize ([bf-precision precision])
-                (rnd 'down bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y)))))
-    (define d (parameterize ([bf-precision precision])
-                (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-lo-val y)))))
-    (cond
-     [(bf=? c d) ; No intersection along `x.hi` either; use top-left/bottom-right point
-      (define lo (rnd 'down bfsub (ival-lo-val x)
-                      (parameterize ([bf-precision precision])
-                        (rnd 'up bfmul* c (ival-hi-val y)))))
-      (define hi (rnd 'up bfsub (ival-hi-val x)
-                      (parameterize ([bf-precision precision])
-                        (rnd 'down bfmul* c (ival-lo-val y)))))
-      (ival (endpoint lo #f)
-            (endpoint hi #f)
-            err? err)]
-     [else
-      (ival (endpoint 0.bf #f)
-            (endpoint (rnd 'up bfmax2 
-                           (parameterize ([bf-precision precision])
-                             (bfdiv (ival-hi-val x) (rnd 'down bfadd c 1.bf)))
-                           0.bf) #f) err? err)])]
-   [else
-    (ival (endpoint 0.bf #f) (endpoint (ival-hi-val y) #f) err? err)]))
+    [(bf=? a b) ; No intersection along `y.hi` edge
+     (define c
+       (parameterize ([bf-precision precision])
+         (rnd 'down bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y)))))
+     (define d
+       (parameterize ([bf-precision precision])
+         (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-lo-val y)))))
+     (cond
+       [(bf=? c d) ; No intersection along `x.hi` either; use top-left/bottom-right point
+        (define lo
+          (rnd 'down
+               bfsub
+               (ival-lo-val x)
+               (parameterize ([bf-precision precision])
+                 (rnd 'up bfmul* c (ival-hi-val y)))))
+        (define hi
+          (rnd 'up
+               bfsub
+               (ival-hi-val x)
+               (parameterize ([bf-precision precision])
+                 (rnd 'down bfmul* c (ival-lo-val y)))))
+        (ival (endpoint lo #f) (endpoint hi #f) err? err)]
+       [else
+        (ival (endpoint 0.bf #f)
+              (endpoint (rnd 'up
+                             bfmax2
+                             (parameterize ([bf-precision precision])
+                               (bfdiv (ival-hi-val x) (rnd 'down bfadd c 1.bf)))
+                             0.bf)
+                        #f)
+              err?
+              err)])]
+    [else (ival (endpoint 0.bf #f) (endpoint (ival-hi-val y) #f) err? err)]))
 
 (define (ival-fmod x y)
-  (define err? (or (ival-err? x) (ival-err? y)
-                   (and (bflte? (ival-lo-val y) 0.bf) (bfgte? (ival-hi-val y) 0.bf))))
-  (define err (or (ival-err x) (ival-err y)
-                  (and (bf=? (ival-lo-val y) 0.bf) (bf=? (ival-hi-val y) 0.bf))))
+  (define err?
+    (or (ival-err? x)
+        (ival-err? y)
+        (and (bflte? (ival-lo-val y) 0.bf) (bfgte? (ival-hi-val y) 0.bf))))
+  (define err
+    (or (ival-err x) (ival-err y) (and (bf=? (ival-lo-val y) 0.bf) (bf=? (ival-hi-val y) 0.bf))))
   (define y* (ival-exact-fabs y))
   (cond
-   [(bflte? (ival-hi-val x) 0.bf)
-    (ival-neg (ival-fmod-pos (ival-exact-neg x) y* err? err))]
-   [(bfgte? (ival-lo-val x) 0.bf)
-    (ival-fmod-pos x y* err? err)]
-   [else
-    (define-values (neg pos) (split-ival x 0.bf))
-    (ival-union (ival-fmod-pos pos y* err? err)
-                (ival-neg (ival-fmod-pos (ival-exact-neg neg) y* err? err)))]))
+    [(bflte? (ival-hi-val x) 0.bf) (ival-neg (ival-fmod-pos (ival-exact-neg x) y* err? err))]
+    [(bfgte? (ival-lo-val x) 0.bf) (ival-fmod-pos x y* err? err)]
+    [else
+     (define-values (neg pos) (split-ival x 0.bf))
+     (ival-union (ival-fmod-pos pos y* err? err)
+                 (ival-neg (ival-fmod-pos (ival-exact-neg neg) y* err? err)))]))
 
 (define (ival-remainder-pos x y err? err)
   ;; Assumes both `x` and `y` are entirely positive
   (define a (rnd 'down bfround (bfdiv (ival-lo-val x) (ival-hi-val y))))
   (define b (rnd 'up bfround (bfdiv (ival-hi-val x) (ival-hi-val y))))
   (cond
-   [(bf=? a b) ; No intersection along `y.hi` edge
-    (define c (rnd 'down bfround (bfdiv (ival-hi-val x) (ival-hi-val y))))
-    (define d (rnd 'up bfround (bfdiv (ival-hi-val x) (ival-lo-val y))))
-    (cond
-     [(bf=? c d) ; No intersection along `x.hi` either; use top-left/bottom-right point
-      (define y* (bfdiv (ival-hi-val y) 2.bf))
-      (ival (endpoint (rnd 'down bfmax2 (bfsub (ival-lo-val x) (rnd 'up bfmul c (ival-hi-val y)))
-                              (bfneg y*)) #f)
-            (endpoint (rnd 'up bfmin2 (bfsub (ival-hi-val x) (rnd 'down bfmul c (ival-lo-val y)))
-                              y*) #f)
-            err? err)]
-     [else
-      ;; NOPE! need to subtract half.bf one way, add it another!
-      (define y*-hi (rnd 'up bfdiv (bfdiv (ival-hi-val x) (bfadd c half.bf)) 2.bf))
-      (define y*-lo (rnd 'down bfmax2
-                         (bfsub (ival-lo-val x) (rnd 'up bfmul c (ival-hi-val y)))
-                         (bfneg (bfdiv (ival-hi-val y) 2.bf))))
-      (ival (endpoint (rnd 'down bfmin2 y*-lo (bfneg y*-hi)) #f) (endpoint y*-hi #f) err? err)])]
-   [else
-    (define y* (rnd 'up bfdiv (ival-hi-val y) 2.bf))
-    (ival (endpoint (rnd 'down bfneg y*) #f) (endpoint y* #f) err? err)]))
+    [(bf=? a b) ; No intersection along `y.hi` edge
+     (define c (rnd 'down bfround (bfdiv (ival-hi-val x) (ival-hi-val y))))
+     (define d (rnd 'up bfround (bfdiv (ival-hi-val x) (ival-lo-val y))))
+     (cond
+       [(bf=? c d) ; No intersection along `x.hi` either; use top-left/bottom-right point
+        (define y* (bfdiv (ival-hi-val y) 2.bf))
+        (ival
+         (endpoint
+          (rnd 'down bfmax2 (bfsub (ival-lo-val x) (rnd 'up bfmul c (ival-hi-val y))) (bfneg y*))
+          #f)
+         (endpoint (rnd 'up bfmin2 (bfsub (ival-hi-val x) (rnd 'down bfmul c (ival-lo-val y))) y*) #f)
+         err?
+         err)]
+       [else
+        ;; NOPE! need to subtract half.bf one way, add it another!
+        (define y*-hi (rnd 'up bfdiv (bfdiv (ival-hi-val x) (bfadd c half.bf)) 2.bf))
+        (define y*-lo
+          (rnd 'down
+               bfmax2
+               (bfsub (ival-lo-val x) (rnd 'up bfmul c (ival-hi-val y)))
+               (bfneg (bfdiv (ival-hi-val y) 2.bf))))
+        (ival (endpoint (rnd 'down bfmin2 y*-lo (bfneg y*-hi)) #f) (endpoint y*-hi #f) err? err)])]
+    [else
+     (define y* (rnd 'up bfdiv (ival-hi-val y) 2.bf))
+     (ival (endpoint (rnd 'down bfneg y*) #f) (endpoint y* #f) err? err)]))
 
 ;; Seems unnecessary
 (define (ival-remainder x y)
-  (define err? (or (ival-err? x) (ival-err? y)
-                   (and (bflte? (ival-lo-val y) 0.bf) (bfgte? (ival-hi-val y) 0.bf))))
-  (define err (or (ival-err x) (ival-err y)
-                  (and (bf=? (ival-lo-val y) 0.bf) (bf=? (ival-hi-val y) 0.bf))))
+  (define err?
+    (or (ival-err? x)
+        (ival-err? y)
+        (and (bflte? (ival-lo-val y) 0.bf) (bfgte? (ival-hi-val y) 0.bf))))
+  (define err
+    (or (ival-err x) (ival-err y) (and (bf=? (ival-lo-val y) 0.bf) (bf=? (ival-hi-val y) 0.bf))))
   (define y* (ival-exact-fabs y))
   (cond
-   [(bflte? (ival-hi-val x) 0.bf)
-    (ival-neg (ival-remainder-pos (ival-exact-neg x) y* err? err))]
-   [(bfgte? (ival-lo-val x) 0.bf)
-    (ival-remainder-pos x y* err? err)]
-   [else
-    (define-values (neg pos) (split-ival x 0.bf))
-    (ival-union (ival-remainder-pos pos y* err? err)
-                (ival-neg (ival-remainder-pos (ival-exact-neg neg) y* err? err)))]))
+    [(bflte? (ival-hi-val x) 0.bf) (ival-neg (ival-remainder-pos (ival-exact-neg x) y* err? err))]
+    [(bfgte? (ival-lo-val x) 0.bf) (ival-remainder-pos x y* err? err)]
+    [else
+     (define-values (neg pos) (split-ival x 0.bf))
+     (ival-union (ival-remainder-pos pos y* err? err)
+                 (ival-neg (ival-remainder-pos (ival-exact-neg neg) y* err? err)))]))

--- a/ops/trig.rkt
+++ b/ops/trig.rkt
@@ -1,7 +1,13 @@
 #lang racket
 
-(require "core.rkt" "../mpfr.rkt")
-(provide ival-sin ival-cos ival-tan ival-cosu ival-sinu ival-tanu)
+(require "core.rkt"
+         "../mpfr.rkt")
+(provide ival-sin
+         ival-cos
+         ival-tan
+         ival-cosu
+         ival-sinu
+         ival-tanu)
 
 (define *rival-precision* (make-parameter (expt 2 20)))
 
@@ -15,15 +21,14 @@
   (cond
     [(or (bfinfinite? xlo) (bfinfinite? xhi)) 'too-wide]
     [(and (< lo-exp period/4) (< hi-exp period/4)) 'near-0]
-    [(or  (> lo-ulp 0) (> hi-ulp 0)) (if (bf=? xlo xhi) 'range-reduce 'too-wide)]
+    [(or (> lo-ulp 0) (> hi-ulp 0)) (if (bf=? xlo xhi) 'range-reduce 'too-wide)]
     [else 'range-reduce]))
 
 (define (range-reduce-precision xlo xhi)
   (min (*rival-precision*)
        (max (bf-precision)
-            (max
-             (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
-             (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi))))))
+            (max (+ (bigfloat-exponent xlo) (bigfloat-precision xlo) (bigfloat-precision xlo))
+                 (+ (bigfloat-exponent xhi) (bigfloat-precision xhi) (bigfloat-precision xhi))))))
 
 (define (ival-cosu n)
   (define (ival-cosu x)
@@ -33,29 +38,42 @@
       ['near-0
        (match (classify-ival x)
          [-1 ((monotonic->ival (curry bfcosu n)) x)]
-         [ 1 ((comonotonic->ival (curry bfcosu n)) x)]
+         [1 ((comonotonic->ival (curry bfcosu n)) x)]
          [else
-          (ival (rnd 'down epfn bfmin2 (epfn (curry bfcosu n) (ival-lo x))
+          (ival (rnd 'down
+                     epfn
+                     bfmin2
+                     (epfn (curry bfcosu n) (ival-lo x))
                      (epfn (curry bfcosu n) (ival-hi x)))
-                (endpoint 1.bf #f) (ival-err? x) (ival-err x))])]
+                (endpoint 1.bf #f)
+                (ival-err? x)
+                (ival-err x))])]
       ['range-reduce
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision (range-reduce-precision xlo xhi)])
            (ival-floor (ival-div x (mk-ival (bf (/ n 2)))))))
        (cond
-         [(and (bf=? a b) (bfeven? a))
-          ((comonotonic->ival (curry bfcosu n)) x)]
-         [(and (bf=? a b) (bfodd? a))
-          ((monotonic->ival (curry bfcosu n)) x)]
+         [(and (bf=? a b) (bfeven? a)) ((comonotonic->ival (curry bfcosu n)) x)]
+         [(and (bf=? a b) (bfodd? a)) ((monotonic->ival (curry bfcosu n)) x)]
          [(and (bf=? (bfsub b a) 1.bf) (bfeven? a))
           (ival (endpoint -1.bf #f)
-                (rnd 'up epfn bfmax2 (epfn (curry bfcosu n) (ival-lo x)) (epfn (curry bfcosu n) (ival-hi x)))
-                (ival-err? x) (ival-err x))]
+                (rnd 'up
+                     epfn
+                     bfmax2
+                     (epfn (curry bfcosu n) (ival-lo x))
+                     (epfn (curry bfcosu n) (ival-hi x)))
+                (ival-err? x)
+                (ival-err x))]
          [(and (bf=? (bfsub b a) 1.bf) (bfodd? a))
-          (ival (rnd 'down epfn bfmin2 (epfn (curry bfcosu n) (ival-lo x)) (epfn (curry bfcosu n) (ival-hi x)))
-                (endpoint 1.bf #f) (ival-err? x) (ival-err x))]
-         [else
-          (ival-then x (mk-big-ival -1.bf 1.bf))])]))
+          (ival (rnd 'down
+                     epfn
+                     bfmin2
+                     (epfn (curry bfcosu n) (ival-lo x))
+                     (epfn (curry bfcosu n) (ival-hi x)))
+                (endpoint 1.bf #f)
+                (ival-err? x)
+                (ival-err x))]
+         [else (ival-then x (mk-big-ival -1.bf 1.bf))])]))
   (if bfcosu ival-cosu #f))
 
 (define (ival-cos x)
@@ -65,33 +83,35 @@
     ['near-0
      (match (classify-ival x)
        [-1 ((monotonic->ival bfcos) x)]
-       [ 1 ((comonotonic->ival bfcos) x)]
+       [1 ((comonotonic->ival bfcos) x)]
        [else
         (ival (rnd 'down epfn bfmin2 (epfn bfcos (ival-lo x)) (epfn bfcos (ival-hi x)))
-              (endpoint 1.bf #f) (ival-err? x) (ival-err x))])]
+              (endpoint 1.bf #f)
+              (ival-err? x)
+              (ival-err x))])]
     ['range-reduce
      (match-define (ival (endpoint a _) (endpoint b _) _ _)
        (parameterize ([bf-precision (range-reduce-precision xlo xhi)])
          (ival-floor (ival-div x (ival-pi)))))
      (cond
-       [(and (bf=? a b) (bfeven? a))
-        ((comonotonic->ival bfcos) x)]
-       [(and (bf=? a b) (bfodd? a))
-        ((monotonic->ival bfcos) x)]
+       [(and (bf=? a b) (bfeven? a)) ((comonotonic->ival bfcos) x)]
+       [(and (bf=? a b) (bfodd? a)) ((monotonic->ival bfcos) x)]
        [(and (bf=? (bfsub b a) 1.bf) (bfeven? a))
         (ival (endpoint -1.bf #f)
               (rnd 'up epfn bfmax2 (epfn bfcos (ival-lo x)) (epfn bfcos (ival-hi x)))
-              (ival-err? x) (ival-err x))]
+              (ival-err? x)
+              (ival-err x))]
        [(and (bf=? (bfsub b a) 1.bf) (bfodd? a))
         (ival (rnd 'down epfn bfmin2 (epfn bfcos (ival-lo x)) (epfn bfcos (ival-hi x)))
-              (endpoint 1.bf #f) (ival-err? x) (ival-err x))]
-       [else
-        (ival-then x (mk-big-ival -1.bf 1.bf))])]))
+              (endpoint 1.bf #f)
+              (ival-err? x)
+              (ival-err x))]
+       [else (ival-then x (mk-big-ival -1.bf 1.bf))])]))
 
 (define (ival-sinu n)
   (define (ival-sinu x)
     (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-    
+
     (match (classify-ival-periodic x n)
       ['too-wide (ival-then x (mk-big-ival -1.bf 1.bf))]
       ['near-0 ((monotonic->ival (curry bfsinu n)) x)]
@@ -100,27 +120,32 @@
          (parameterize ([bf-precision (range-reduce-precision xlo xhi)])
            (ival-round (ival-div x (mk-ival (bf (/ n 2)))))))
        (cond
-         [(and (bf=? a b) (bfodd? a))
-          ((comonotonic->ival (curry bfsinu n)) x)]
-         [(and (bf=? a b) (bfeven? a))
-          ((monotonic->ival (curry bfsinu n)) x)]
+         [(and (bf=? a b) (bfodd? a)) ((comonotonic->ival (curry bfsinu n)) x)]
+         [(and (bf=? a b) (bfeven? a)) ((monotonic->ival (curry bfsinu n)) x)]
          [(and (bf=? (bfsub b a) 1.bf) (bfodd? a))
           (ival (endpoint -1.bf #f)
-                (rnd 'up epfn bfmax2 (epfn (curry bfsinu n) (ival-lo x)) (epfn (curry bfsinu n) (ival-hi x)))
+                (rnd 'up
+                     epfn
+                     bfmax2
+                     (epfn (curry bfsinu n) (ival-lo x))
+                     (epfn (curry bfsinu n) (ival-hi x)))
                 (ival-err? x)
                 (ival-err x))]
          [(and (bf=? (bfsub b a) 1.bf) (bfeven? a))
-          (ival (rnd 'down epfn bfmin2 (epfn (curry bfsinu n) (ival-lo x)) (epfn (curry bfsinu n) (ival-hi x)))
+          (ival (rnd 'down
+                     epfn
+                     bfmin2
+                     (epfn (curry bfsinu n) (ival-lo x))
+                     (epfn (curry bfsinu n) (ival-hi x)))
                 (endpoint 1.bf #f)
                 (ival-err? x)
                 (ival-err x))]
-         [else
-          (ival-then x (mk-big-ival -1.bf 1.bf))])]))
+         [else (ival-then x (mk-big-ival -1.bf 1.bf))])]))
   (if bfsinu ival-sinu #f))
 
 (define (ival-sin x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-  
+
   (match (classify-ival-periodic x (* 2 pi))
     ['too-wide (ival-then x (mk-big-ival -1.bf 1.bf))]
     ['near-0 ((monotonic->ival bfsin) x)]
@@ -129,10 +154,8 @@
        (parameterize ([bf-precision (range-reduce-precision xlo xhi)])
          (ival-round (ival-div x (ival-pi)))))
      (cond
-       [(and (bf=? a b) (bfodd? a))
-        ((comonotonic->ival bfsin) x)]
-       [(and (bf=? a b) (bfeven? a))
-        ((monotonic->ival bfsin) x)]
+       [(and (bf=? a b) (bfodd? a)) ((comonotonic->ival bfsin) x)]
+       [(and (bf=? a b) (bfeven? a)) ((monotonic->ival bfsin) x)]
        [(and (bf=? (bfsub b a) 1.bf) (bfodd? a))
         (ival (endpoint -1.bf #f)
               (rnd 'up epfn bfmax2 (epfn bfsin (ival-lo x)) (epfn bfsin (ival-hi x)))
@@ -143,41 +166,36 @@
               (endpoint 1.bf #f)
               (ival-err? x)
               (ival-err x))]
-       [else
-        (ival-then x (mk-big-ival -1.bf 1.bf))])]))
+       [else (ival-then x (mk-big-ival -1.bf 1.bf))])]))
 
 (define (ival-tanu n)
   (define (ival-tanu x)
     (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-    
+
     (match (classify-ival-periodic x (/ n 2))
-      ['too-wide
-       (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!)) #t xerr)]
+      ['too-wide (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!)) #t xerr)]
       ['near-0 ((monotonic->ival (curry bftanu n)) x)]
       ['range-reduce
        (match-define (ival (endpoint a _) (endpoint b _) _ _)
          (parameterize ([bf-precision (range-reduce-precision xlo xhi)])
            (ival-round (ival-div x (mk-ival (bf (/ n 2)))))))
-    
+
        (if (bf=? a b) ; Same period
            ((monotonic->ival (curry bftanu n)) x)
-           (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!))
-                 #t xerr))]))
+           (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!)) #t xerr))]))
   (if bftanu ival-tanu #f))
 
 (define (ival-tan x)
   (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-  
+
   (match (classify-ival-periodic x pi)
-    ['too-wide
-     (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!)) #t xerr)]
+    ['too-wide (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!)) #t xerr)]
     ['near-0 ((monotonic->ival bftan) x)]
     ['range-reduce
      (match-define (ival (endpoint a _) (endpoint b _) _ _)
        (parameterize ([bf-precision (range-reduce-precision xlo xhi)])
          (ival-round (ival-div x (ival-pi)))))
-  
+
      (if (bf=? a b) ; Same period
          ((monotonic->ival bftan) x)
-         (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!))
-               #t xerr))]))
+         (ival (endpoint -inf.bf (and xlo! xhi!)) (endpoint +inf.bf (and xlo! xhi!)) #t xerr))]))

--- a/profile.rkt
+++ b/profile.rkt
@@ -13,36 +13,49 @@
     (for/hash ([node (in-list nodes)])
       (values (node-loc node) node)))
 
-  (hash 'total_time (exact->inexact (profile-total-time p))
-        'cpu_time (exact->inexact (profile-cpu-time p))
-        'sample_number (profile-sample-number p)
+  (hash 'total_time
+        (exact->inexact (profile-total-time p))
+        'cpu_time
+        (exact->inexact (profile-cpu-time p))
+        'sample_number
+        (profile-sample-number p)
         'thread_times
         (for/list ([(id time) (in-dict (profile-thread-times p))])
           (hash 'id id 'time (exact->inexact time)))
         'nodes
         (for/list ([node nodes])
-          (hash 'id (and (node-id node) (~a (node-id node)))
-                'src (and (node-src node) (srcloc->string (node-src node)))
-                'thread_ids (node-thread-ids node)
-                'total (exact->inexact (node-total node))
-                'self (exact->inexact (node-self node))
-                'callers (map (curry edge->json loc-hash) (node-callers node))
-                'callees (map (curry edge->json loc-hash) (node-callees node))))))
+          (hash 'id
+                (and (node-id node) (~a (node-id node)))
+                'src
+                (and (node-src node) (srcloc->string (node-src node)))
+                'thread_ids
+                (node-thread-ids node)
+                'total
+                (exact->inexact (node-total node))
+                'self
+                (exact->inexact (node-self node))
+                'callers
+                (map (curry edge->json loc-hash) (node-callers node))
+                'callees
+                (map (curry edge->json loc-hash) (node-callees node))))))
 
 (define (node-loc node)
   (cons (node-id node) (node-src node)))
 
 (define (edge->json loc-hash edge)
-  (hash 'total (exact->inexact (edge-total edge))
-        'caller (hash-ref loc-hash (node-loc (edge-caller edge)))
-        'caller_time (exact->inexact (edge-caller-time edge))
-        'callee (hash-ref loc-hash (node-loc (edge-callee edge)))
-        'callee_time (exact->inexact (edge-callee-time edge))))
+  (hash 'total
+        (exact->inexact (edge-total edge))
+        'caller
+        (hash-ref loc-hash (node-loc (edge-caller edge)))
+        'caller_time
+        (exact->inexact (edge-caller-time edge))
+        'callee
+        (hash-ref loc-hash (node-loc (edge-callee edge)))
+        'callee_time
+        (exact->inexact (edge-callee-time edge))))
 
 (define (string->srcloc s)
   (match-define (list path-parts ... (app string->number line) (app string->number col))
-                (string-split s ":" #:trim? #f))
+    (string-split s ":" #:trim? #f))
   (define path (string->path (string-join path-parts ":")))
   (srcloc path line (and line col) #f #f))
-
-

--- a/repl.rkt
+++ b/repl.rkt
@@ -1,7 +1,14 @@
 #lang racket
 
-(require (only-in math/private/bigfloat/mpfr bfcopy bigfloats-between bf-precision bigfloat->string bf))
-(require "eval/main.rkt" "eval/machine.rkt" "utils.rkt")
+(require (only-in math/private/bigfloat/mpfr
+                  bfcopy
+                  bigfloats-between
+                  bf-precision
+                  bigfloat->string
+                  bf))
+(require "eval/main.rkt"
+         "eval/machine.rkt"
+         "utils.rkt")
 (provide rival-repl)
 
 (define (fix-up-fpcore expr)
@@ -12,9 +19,7 @@
     [_ expr]))
 
 (define (normalize-function-name name)
-  (if (string-prefix? name "ival-")
-      (substring name 5)
-      name))
+  (if (string-prefix? name "ival-") (substring name 5) name))
 
 (define (executions-iterations execs)
   (define iter 0)
@@ -37,10 +42,8 @@
     (match l
       [(cons pattern rest)
        body ...]
-      [(cons _ rest)
-       (loop rest)]
-      ['()
-       ""])))
+      [(cons _ rest) (loop rest)]
+      ['() ""])))
 
 (struct repl ([precision #:mutable] context))
 
@@ -62,15 +65,18 @@
       (vector-ref (rival-apply machine (list->vector (map bf vals))) 0))))
 
 (define (repl-save-machine! repl name args body)
-  (hash-set! (repl-context repl) name
-             (rival-compile (list (fix-up-fpcore body)) args
-                            (list (bf-discretization (repl-precision repl))))))
+  (hash-set!
+   (repl-context repl)
+   name
+   (rival-compile (list (fix-up-fpcore body)) args (list (bf-discretization (repl-precision repl))))))
 
 (define (check-args! name machine vals)
   (unless (= (vector-length (rival-machine-arguments machine)) (length vals))
     (define args (rival-machine-arguments machine))
-    (raise-user-error name "Expects ~a arguments: ~a"
-                      (length args) (string-join " " (map symbol->string args)))))
+    (raise-user-error name
+                      "Expects ~a arguments: ~a"
+                      (length args)
+                      (string-join " " (map symbol->string args)))))
 
 (define (write-explain machine)
   (define execs (rival-profile machine 'executions))
@@ -80,94 +86,110 @@
   (printf "Executed ~a instructions for ~a iterations:\n\n" num-instructions num-iterations)
 
   (define execs* (executions-iterations execs))
-  (write-table
-   #:rows (+ 5 num-instructions) ; 1 for the "adjust" row
-   #:cols (+ 1 (* 2 num-iterations))
-   #:width 6
-   (lambda (row col)
-     (match* (row col)
-       [(0 0) ""]
-       [(0 col) #:when (= (modulo col 2) 1) "Bits"]
-       [(0 col) #:when (= (modulo col 2) 0) "Time"]
-       [(1 _) "------"]
-       [(2 0) 'adjust]
-       [(2 col) #:when (and (= (modulo col 2) 0) (> col 2))
-        (define iter (- (/ col 2) 1))
-        (list-find-match execs* (cons (== iter) (execution 'adjust _ _ time))
-          (~r (* time 1000) #:precision '(= 1)))]
-       [(2 col) ""]
-       [((== (+ 3 num-instructions)) _) "------"]
-       [((== (+ 4 num-instructions)) 0) "Total"]
-       [((== (+ 4 num-instructions)) col) #:when (= (modulo col 2) 1) ""]
-       [((== (+ 4 num-instructions)) col) #:when (= (modulo col 2) 0)
-        (define iter (/ (- col 2) 2))
-        (define time
-          (apply + (for/list ([exec (in-list execs*)] #:when (= (car exec) iter))
-                     (execution-time (cdr exec)))))
-        (~r (* time 1000) #:precision '(= 1))]
-       [(row 0)
-        (define id (+ (- row 3) num-args))
-        (list-find-match execs* (cons _ (execution name (== id) _ _))
-          (normalize-function-name (~a name)))]
-       [(row col) #:when (= (modulo col 2) 1) ; precision
-        (define id (+ (- row 3) num-args))
-        (define iter (/ (- col 1) 2))
-        (list-find-match execs* (cons (== iter) (execution _ (== id) prec _))
-          prec)]
-       [(row col) #:when (= (modulo col 2) 0) ; time
-        (define id (+ (- row 3) num-args))
-        (define iter (/ (- col 2) 2))
-        (list-find-match execs* (cons (== iter) (execution _ (== id) _ time))
-          (~r (* time 1000) #:precision '(= 1)))]))))
+  (write-table #:rows (+ 5 num-instructions) ; 1 for the "adjust" row
+               #:cols (+ 1 (* 2 num-iterations))
+               #:width 6
+               (lambda (row col)
+                 (match* (row col)
+                   [(0 0) ""]
+                   [(0 col)
+                    #:when (= (modulo col 2) 1)
+                    "Bits"]
+                   [(0 col)
+                    #:when (= (modulo col 2) 0)
+                    "Time"]
+                   [(1 _) "------"]
+                   [(2 0) 'adjust]
+                   [(2 col)
+                    #:when (and (= (modulo col 2) 0) (> col 2))
+                    (define iter (- (/ col 2) 1))
+                    (list-find-match execs*
+                                     (cons (== iter) (execution 'adjust _ _ time))
+                                     (~r (* time 1000) #:precision '(= 1)))]
+                   [(2 col) ""]
+                   [((== (+ 3 num-instructions)) _) "------"]
+                   [((== (+ 4 num-instructions)) 0) "Total"]
+                   [((== (+ 4 num-instructions)) col)
+                    #:when (= (modulo col 2) 1)
+                    ""]
+                   [((== (+ 4 num-instructions)) col)
+                    #:when (= (modulo col 2) 0)
+                    (define iter (/ (- col 2) 2))
+                    (define time
+                      (apply +
+                             (for/list ([exec (in-list execs*)] #:when (= (car exec) iter))
+                               (execution-time (cdr exec)))))
+                    (~r (* time 1000) #:precision '(= 1))]
+                   [(row 0)
+                    (define id (+ (- row 3) num-args))
+                    (list-find-match execs*
+                                     (cons _ (execution name (== id) _ _))
+                                     (normalize-function-name (~a name)))]
+                   [(row col)
+                    #:when (= (modulo col 2) 1) ; precision
+                    (define id (+ (- row 3) num-args))
+                    (define iter (/ (- col 1) 2))
+                    (list-find-match execs* (cons (== iter) (execution _ (== id) prec _)) prec)]
+                   [(row col)
+                    #:when (= (modulo col 2) 0) ; time
+                    (define id (+ (- row 3) num-args))
+                    (define iter (/ (- col 2) 2))
+                    (list-find-match execs*
+                                     (cons (== iter) (execution _ (== id) _ time))
+                                     (~r (* time 1000) #:precision '(= 1)))]))))
 
 (define (rival-repl p)
-  (let/ec k
-    (parameterize ([read-decimal-as-inexact #f] [*rival-name-constants* #t])
-      (define repl (make-repl))
-      (when (terminal-port? p) (display "> "))
-      (for ([cmd (in-port read p)])
-        (match cmd
-          [`(set precision ,(? integer? n))
-           (when (< n 4)
-             (raise-user-error 'set "Precision must be an integer greater than 3"))
-           (set-repl-precision! repl n)]
-          [`(define (,(? symbol? name) ,(? symbol? args) ...) ,body)
-           (repl-save-machine! repl name args body)]
-          [`(eval ,name ,(? real? vals) ...)
-           (define machine (repl-get-machine repl name))
-           (check-args! name machine vals)
-           (define out (repl-apply repl machine vals))
-           (displayln (if (string? out) out (bigfloat->string out)))]
-          [`(explain ,name ,(? real? vals) ...)
-           (define machine (repl-get-machine repl name))
-           (check-args! name machine vals)
-  
-           ;; Make sure the cache is warm
-           (repl-apply repl machine vals)
-           ;; Make sure the profile is clear
-           (rival-profile machine 'executions)
-  
-           ;; Time the actual execution
-           (define start (current-inexact-milliseconds))
-           (repl-apply repl machine vals)
-           (define end (current-inexact-milliseconds))
-  
-           (write-explain machine)
-  
-           (printf "\nTotal: ~aµs\n" (~r (* (- end start) 1000) #:precision '(= 1)))]
-          [(or '(help) 'help)
-           (displayln "This is the Rival REPL, a demo of the Rival real evaluator.")
-           (newline)
-           (displayln "Commands:")
-           (displayln "  (set precision <n>)                  Set working precision to n")
-           (displayln "  (define (<name> <args> ...) <body>)  Define a named function")
-           (displayln "  (eval <name> <vals> ...)             Evaluate a named function")
-           (displayln "  (explain <name> <vals> ...)          Show profile for evaluating a named function")
-           (newline)
-           (displayln "A closed expression can always be used in place of a named function.")]
-          [(or '(exit) 'exit)
-           (k)]
-          [_
-           (printf "Unknown command ~a; use help for command list\n" cmd)])
-        (when (terminal-port? p) (display "> "))))
-    (when (terminal-port? p) (displayln "exit"))))
+  (let/ec
+   k
+   (parameterize ([read-decimal-as-inexact #f] [*rival-name-constants* #t])
+     (define repl (make-repl))
+     (when (terminal-port? p)
+       (display "> "))
+     (for ([cmd (in-port read p)])
+       (match cmd
+         [`(set precision ,(? integer? n))
+          (when (< n 4)
+            (raise-user-error 'set "Precision must be an integer greater than 3"))
+          (set-repl-precision! repl n)]
+         [`(define (,(? symbol? name) ,(? symbol? args) ...)
+             ,body)
+          (repl-save-machine! repl name args body)]
+         [`(eval ,name ,(? real? vals) ...)
+          (define machine (repl-get-machine repl name))
+          (check-args! name machine vals)
+          (define out (repl-apply repl machine vals))
+          (displayln (if (string? out) out (bigfloat->string out)))]
+         [`(explain ,name ,(? real? vals) ...)
+          (define machine (repl-get-machine repl name))
+          (check-args! name machine vals)
+
+          ;; Make sure the cache is warm
+          (repl-apply repl machine vals)
+          ;; Make sure the profile is clear
+          (rival-profile machine 'executions)
+
+          ;; Time the actual execution
+          (define start (current-inexact-milliseconds))
+          (repl-apply repl machine vals)
+          (define end (current-inexact-milliseconds))
+
+          (write-explain machine)
+
+          (printf "\nTotal: ~aµs\n" (~r (* (- end start) 1000) #:precision '(= 1)))]
+         [(or '(help) 'help)
+          (displayln "This is the Rival REPL, a demo of the Rival real evaluator.")
+          (newline)
+          (displayln "Commands:")
+          (displayln "  (set precision <n>)                  Set working precision to n")
+          (displayln "  (define (<name> <args> ...) <body>)  Define a named function")
+          (displayln "  (eval <name> <vals> ...)             Evaluate a named function")
+          (displayln
+           "  (explain <name> <vals> ...)          Show profile for evaluating a named function")
+          (newline)
+          (displayln "A closed expression can always be used in place of a named function.")]
+         [(or '(exit) 'exit) (k)]
+         [_ (printf "Unknown command ~a; use help for command list\n" cmd)])
+       (when (terminal-port? p)
+         (display "> "))))
+   (when (terminal-port? p)
+     (displayln "exit"))))

--- a/test.rkt
+++ b/test.rkt
@@ -1,9 +1,30 @@
 #lang racket
 
-(require racket/math math/base math/flonum (only-in math/bigfloat bf> bf< bf= bf>= bf<= bf- bf+ bf* bf/ bfmin bfmax bfshift bigfloat->flonum))
+(require racket/math
+         math/base
+         math/flonum
+         (only-in math/bigfloat
+                  bf>
+                  bf<
+                  bf=
+                  bf>=
+                  bf<=
+                  bf-
+                  bf+
+                  bf*
+                  bf/
+                  bfmin
+                  bfmax
+                  bfshift
+                  bigfloat->flonum))
 (require rackunit)
-(require "main.rkt" "mpfr.rkt")
-(provide ival-valid? function-table sample-interval slow-tests sample-from)
+(require "main.rkt"
+         "mpfr.rkt")
+(provide ival-valid?
+         function-table
+         sample-interval
+         slow-tests
+         sample-from)
 
 (define (ival-valid? ival)
   (if (ival-err ival)
@@ -16,25 +37,26 @@
 
 (define (ival-contains? ival pt)
   (if (bigfloat? pt)
-      (cond 
-       [(bfnan? pt)
-        (ival-err? ival)]
-       [(bfinfinite? pt)
+      (cond
+        [(bfnan? pt) (ival-err? ival)]
         ;; This could be a real value rounded up, or a true infinity
         ;; In theory, we could check the exact flag to determine this,
         ;; but some of the functions we code up don't set that flag.
-        true]
-       [else
-        (and (not (ival-err ival))
-             (if (equal? (bigfloat-precision pt) (bigfloat-precision (ival-lo ival))) 
-                 (bf<= (ival-lo ival) pt)
-                 (bf<= (parameterize ([bf-precision (bigfloat-precision pt)] [bf-rounding-mode 'down]) (bfcopy (ival-lo ival))) pt))
-             (if (equal? (bigfloat-precision pt) (bigfloat-precision (ival-hi ival))) 
-                 (bf<= pt (ival-hi ival))
-                 (bf<= pt (parameterize ([bf-precision (bigfloat-precision pt)] [bf-rounding-mode 'up]) (bfcopy (ival-hi ival))))))])
-      (and (not (ival-err ival))
-           (or (equal? pt (ival-lo ival))
-               (equal? pt (ival-hi ival))))))
+        [(bfinfinite? pt) true]
+        [else
+         (and (not (ival-err ival))
+              (if (equal? (bigfloat-precision pt) (bigfloat-precision (ival-lo ival)))
+                  (bf<= (ival-lo ival) pt)
+                  (bf<= (parameterize ([bf-precision (bigfloat-precision pt)]
+                                       [bf-rounding-mode 'down])
+                          (bfcopy (ival-lo ival)))
+                        pt))
+              (if (equal? (bigfloat-precision pt) (bigfloat-precision (ival-hi ival)))
+                  (bf<= pt (ival-hi ival))
+                  (bf<= pt
+                        (parameterize ([bf-precision (bigfloat-precision pt)] [bf-rounding-mode 'up])
+                          (bfcopy (ival-hi ival))))))])
+      (and (not (ival-err ival)) (or (equal? pt (ival-lo ival)) (equal? pt (ival-hi ival))))))
 
 (define (value-equals? bf1 bf2 [rnd-mode 'nearest])
   (if (boolean? bf1)
@@ -43,109 +65,93 @@
 
 (define (bigfloats-equal? x y rnd-mode)
   (cond
-     [(< (bigfloat-precision x) (bigfloat-precision y))
-      (bf= x (parameterize ([bf-rounding-mode rnd-mode] [bf-precision (bigfloat-precision x)]) (bfcopy y)))]
-     [(> (bigfloat-precision x) (bigfloat-precision y))
-      (bf= y (parameterize ([bf-rounding-mode rnd-mode] [bf-precision (bigfloat-precision y)]) (bfcopy x)))]
-     [else (bf= y x)]))
-    
+    [(< (bigfloat-precision x) (bigfloat-precision y))
+     (bf= x
+          (parameterize ([bf-rounding-mode rnd-mode] [bf-precision (bigfloat-precision x)])
+            (bfcopy y)))]
+    [(> (bigfloat-precision x) (bigfloat-precision y))
+     (bf= y
+          (parameterize ([bf-rounding-mode rnd-mode] [bf-precision (bigfloat-precision y)])
+            (bfcopy x)))]
+    [else (bf= y x)]))
 
 (define (value-lte? bf1 bf2)
-  (if (boolean? bf1)
-      (or (not bf1) bf2)
-      (bf<= bf1 bf2)))
+  (if (boolean? bf1) (or (not bf1) bf2) (bf<= bf1 bf2)))
 
 (define (ival-refines? coarse fine)
   (and
    (or (ival-err fine)
-       (and
-        ((if (ival-lo-fixed? coarse) value-equals? value-lte?)
-         (ival-lo coarse) (ival-lo fine))
-        ((if (ival-hi-fixed? coarse) value-equals? value-lte?)
-         (ival-hi fine) (ival-hi coarse))))
+       (and ((if (ival-lo-fixed? coarse) value-equals? value-lte?) (ival-lo coarse) (ival-lo fine))
+            ((if (ival-hi-fixed? coarse) value-equals? value-lte?) (ival-hi fine) (ival-hi coarse))))
    (if (ival-lo-fixed? coarse) (ival-lo-fixed? fine) #t)
    (if (ival-hi-fixed? coarse) (ival-hi-fixed? fine) #t)
    (if (ival-err? fine) (ival-err? coarse) #t)
    (if (ival-err coarse) (ival-err fine) #t)))
 
 (define (bfatan2-no0 y x)
-  (if (and (bfzero? y) (bfzero? x))
-      +nan.bf
-      (bfatan2 y x)))
+  (if (and (bfzero? y) (bfzero? x)) +nan.bf (bfatan2 y x)))
 
 (define ((bftrig-narrow fn) x)
-  (if (> (+ (bigfloat-exponent x) (bigfloat-precision x)) (expt 2 20))
-      0.bf
-      (fn x)))
+  (if (> (+ (bigfloat-exponent x) (bigfloat-precision x)) (expt 2 20)) 0.bf (fn x)))
 
 (define function-table
-  (list (list ival-neg   bf-        '(real) 'real)
-        (list ival-fabs  bfabs      '(real) 'real)
-        (list ival-add   bf+        '(real real) 'real)
-        (list ival-sub   bf-        '(real real) 'real)
-        (list ival-mult  bf*        '(real real) 'real)
-        (list ival-div   bf/        '(real real) 'real)
-        (list ival-fma   bffma      '(real real real) 'real)
-        (list ival-sqrt  bfsqrt     '(real) 'real)
-        (list ival-hypot bfhypot    '(real real) 'real)
-
-        (list ival-rint  bfrint     '(real) 'real)
-        (list ival-round bfround    '(real) 'real)
-        (list ival-ceil  bfceiling  '(real) 'real)
-        (list ival-floor bffloor    '(real) 'real)
+  (list (list ival-neg bf- '(real) 'real)
+        (list ival-fabs bfabs '(real) 'real)
+        (list ival-add bf+ '(real real) 'real)
+        (list ival-sub bf- '(real real) 'real)
+        (list ival-mult bf* '(real real) 'real)
+        (list ival-div bf/ '(real real) 'real)
+        (list ival-fma bffma '(real real real) 'real)
+        (list ival-sqrt bfsqrt '(real) 'real)
+        (list ival-hypot bfhypot '(real real) 'real)
+        (list ival-rint bfrint '(real) 'real)
+        (list ival-round bfround '(real) 'real)
+        (list ival-ceil bfceiling '(real) 'real)
+        (list ival-floor bffloor '(real) 'real)
         (list ival-trunc bftruncate '(real) 'real)
-
-        (list ival-cbrt  bfcbrt     '(real) 'real)
-        (list ival-exp   bfexp      '(real) 'real)
-        (list ival-exp2  bfexp2     '(real) 'real)
-        (list ival-expm1 bfexpm1    '(real) 'real)
-        (list ival-log   bflog      '(real) 'real)
-        (list ival-log2  bflog2     '(real) 'real)
-        (list ival-log10 bflog10    '(real) 'real)
-        (list ival-log1p bflog1p    '(real) 'real)
-        (list ival-logb  bflogb     '(real) 'real)
-        (list ival-pow   bfexpt     '(real real) 'real)
-
-        (list ival-sin   (bftrig-narrow bfsin) '(real) 'real)
-        (list ival-cos   (bftrig-narrow bfcos) '(real) 'real)
-        (list ival-tan   (bftrig-narrow bftan) '(real) 'real)
-        (list ival-asin  bfasin     '(real) 'real)
-        (list ival-acos  bfacos     '(real) 'real)
-        (list ival-atan  bfatan     '(real) 'real)
+        (list ival-cbrt bfcbrt '(real) 'real)
+        (list ival-exp bfexp '(real) 'real)
+        (list ival-exp2 bfexp2 '(real) 'real)
+        (list ival-expm1 bfexpm1 '(real) 'real)
+        (list ival-log bflog '(real) 'real)
+        (list ival-log2 bflog2 '(real) 'real)
+        (list ival-log10 bflog10 '(real) 'real)
+        (list ival-log1p bflog1p '(real) 'real)
+        (list ival-logb bflogb '(real) 'real)
+        (list ival-pow bfexpt '(real real) 'real)
+        (list ival-sin (bftrig-narrow bfsin) '(real) 'real)
+        (list ival-cos (bftrig-narrow bfcos) '(real) 'real)
+        (list ival-tan (bftrig-narrow bftan) '(real) 'real)
+        (list ival-asin bfasin '(real) 'real)
+        (list ival-acos bfacos '(real) 'real)
+        (list ival-atan bfatan '(real) 'real)
         (list ival-atan2 bfatan2-no0 '(real real) 'real)
-
-        (list ival-sinh  bfsinh     '(real) 'real)
-        (list ival-cosh  bfcosh     '(real) 'real)
-        (list ival-tanh  bftanh     '(real) 'real)
-        (list ival-asinh bfasinh    '(real) 'real)
-        (list ival-acosh bfacosh    '(real) 'real)
-        (list ival-atanh bfatanh    '(real) 'real)
-
-        (list ival-fmod  bffmod     '(real real) 'real)
+        (list ival-sinh bfsinh '(real) 'real)
+        (list ival-cosh bfcosh '(real) 'real)
+        (list ival-tanh bftanh '(real) 'real)
+        (list ival-asinh bfasinh '(real) 'real)
+        (list ival-acosh bfacosh '(real) 'real)
+        (list ival-atanh bfatanh '(real) 'real)
+        (list ival-fmod bffmod '(real real) 'real)
         (list ival-remainder bfremainder '(real real) 'real)
-
-        (list ival-fmin  bfmin      '(real real) 'real)
-        (list ival-fmax  bfmax      '(real real) 'real)
+        (list ival-fmin bfmin '(real real) 'real)
+        (list ival-fmax bfmax '(real real) 'real)
         (list ival-copysign bfcopysign '(real real) 'real)
-        (list ival-fdim  bffdim     '(real real) 'real)
-
-        (list ival-<     bf<        '(real real) 'bool)
-        (list ival-<=    bf<=       '(real real) 'bool)
-        (list ival->     bf>        '(real real) 'bool)
-        (list ival->=    bf>=       '(real real) 'bool)
-        (list ival-==    bf=        '(real real) 'bool)
-        (list ival-!=  (negate bf=) '(real real) 'bool)
-
-        (list ival-and   and-fn     '(bool bool bool) 'bool)
-        (list ival-or    or-fn      '(bool bool bool) 'bool)
-        (list ival-not   not        '(bool) 'bool)
-        (list ival-if    if-fn      '(bool real real) 'real)
-
-        (list ival-erf   bferf      '(real) 'real)
-        (list ival-erfc  bferfc     '(real) 'real)
+        (list ival-fdim bffdim '(real real) 'real)
+        (list ival-< bf< '(real real) 'bool)
+        (list ival-<= bf<= '(real real) 'bool)
+        (list ival-> bf> '(real real) 'bool)
+        (list ival->= bf>= '(real real) 'bool)
+        (list ival-== bf= '(real real) 'bool)
+        (list ival-!= (negate bf=) '(real real) 'bool)
+        (list ival-and and-fn '(bool bool bool) 'bool)
+        (list ival-or or-fn '(bool bool bool) 'bool)
+        (list ival-not not '(bool) 'bool)
+        (list ival-if if-fn '(bool real real) 'real)
+        (list ival-erf bferf '(real) 'real)
+        (list ival-erfc bferfc '(real) 'real)
         (list ival-lgamma bflog-gamma '(real) 'real)
-        (list ival-tgamma bfgamma   '(real) 'real)
-        ))
+        (list ival-tgamma bfgamma '(real) 'real)))
 
 (define (sample-precision)
   (random 40 100))
@@ -160,10 +166,18 @@
        [3 (bf 0.0)]
        [4 (bf 1)]
        [5 (bf +inf.0)]
-       [6 (parameterize ([bf-rounding-mode 'down]) (pi.bf))]
-       [7 (parameterize ([bf-rounding-mode 'up]) (pi.bf))]
-       [8 (parameterize ([bf-rounding-mode 'down]) (bf- (pi.bf)))]
-       [9 (parameterize ([bf-rounding-mode 'up]) (bf- (pi.bf)))])]
+       [6
+        (parameterize ([bf-rounding-mode 'down])
+          (pi.bf))]
+       [7
+        (parameterize ([bf-rounding-mode 'up])
+          (pi.bf))]
+       [8
+        (parameterize ([bf-rounding-mode 'down])
+          (bf- (pi.bf)))]
+       [9
+        (parameterize ([bf-rounding-mode 'up])
+          (bf- (pi.bf)))])]
     [else
      (define exponent (random -1023 1023)) ; Pretend-double
      (define significand (bf (random-bits (bf-precision)) (- (bf-precision))))
@@ -180,7 +194,11 @@
 (define (sample-narrow-interval v1)
   ;; Biased toward small intervals
   (define size (random 1 (bf-precision)))
-  (define delta (* (match (random 0 2) [0 -1] [1 1]) size))
+  (define delta
+    (* (match (random 0 2)
+         [0 -1]
+         [1 1])
+       size))
   (define v2 (bfstep v1 delta))
   (ival (bfmin v1 v2) (bfmax v1 v2)))
 
@@ -191,8 +209,9 @@
      (define value (sample-bigfloat))
      (define x
        (match mode
-         [0 #:when (not (bfinfinite? value))
-            (sample-constant-interval value)]
+         [0
+          #:when (not (bfinfinite? value))
+          (sample-constant-interval value)]
          [1 (sample-narrow-interval value)]
          [_ (sample-wide-interval value)]))
      (if (ival-err x) (sample-interval type) x)]
@@ -217,17 +236,15 @@
          (define range (- (bigfloats-between (ival-lo ival) (ival-hi ival)) reduction))
          (define offset (+ (if (bfinfinite? (ival-lo ival)) 1 0) (random-natural (+ range 1))))
          (bfstep (ival-lo ival) offset)])
-      (let ([p (random 0 2)])
-        (if (= p 0) (ival-lo ival) (ival-hi ival)))))
+      (let ([p (random 0 2)]) (if (= p 0) (ival-lo ival) (ival-hi ival)))))
 
-(define-simple-check (check-ival-valid? ival)
-  (ival-valid? ival))
+(define-simple-check (check-ival-valid? ival) (ival-valid? ival))
 
 (define-binary-check (check-ival-equals? ival1 ival2)
-  (if (ival-err ival1)
-      (ival-err ival2)
-      (and (value-equals? (ival-lo ival1) (ival-lo ival2) 'down)
-           (value-equals? (ival-hi ival1) (ival-hi ival2) 'up))))
+                     (if (ival-err ival1)
+                         (ival-err ival2)
+                         (and (value-equals? (ival-lo ival1) (ival-lo ival2) 'down)
+                              (value-equals? (ival-hi ival1) (ival-hi ival2) 'up))))
 
 (define num-tests 1000)
 (define num-witnesses 10)
@@ -237,41 +254,53 @@
 
 (define (test-entry ival-fn fn args)
   (define out-prec (sample-precision))
-  (define in-precs (for/list ([arg args]) (sample-precision)))
+  (define in-precs
+    (for/list ([arg args])
+      (sample-precision)))
 
-  (define is (for/list ([arg args] [in-prec in-precs])
-               (parameterize ([bf-precision in-prec])
-                 (sample-interval arg))))
-  (define iy (parameterize ([bf-precision out-prec]) (apply ival-fn is)))
+  (define is
+    (for/list ([arg args] [in-prec in-precs])
+      (parameterize ([bf-precision in-prec])
+        (sample-interval arg))))
+  (define iy
+    (parameterize ([bf-precision out-prec])
+      (apply ival-fn is)))
 
-  (with-check-info (['intervals is])
-    (check-ival-valid? iy))
+  (with-check-info (['intervals is]) (check-ival-valid? iy))
 
   (define xs #f)
   (define y #f)
   (for ([_ (in-range num-witnesses)])
-    (set! xs (for/list ([i is] [in-prec in-precs])
-               (parameterize ([bf-precision in-prec])
-                 (sample-from i))))
-    (set! y (parameterize ([bf-precision out-prec]) (apply fn xs)))
+    (set! xs
+          (for/list ([i is] [in-prec in-precs])
+            (parameterize ([bf-precision in-prec])
+              (sample-from i))))
+    (set! y
+          (parameterize ([bf-precision out-prec])
+            (apply fn xs)))
     (with-check-info (['intervals is] ['points xs] ['precs (list out-prec in-precs)])
-      (check ival-contains? iy y)))
+                     (check ival-contains? iy y)))
 
-  (with-check-info (['intervals is] ['points xs] ['iy iy] ['y y] ['precs (list out-prec in-precs)])
-    (for ([k (in-naturals)] [i is] [x xs])
-      (define-values (ilo ihi) (ival-split i x))
-      (when (and ilo ihi)
-        (define iylo (parameterize ([bf-precision out-prec])
-                       (apply ival-fn (list-set is k ilo))))
-        (define iyhi (parameterize ([bf-precision out-prec])
-                       (apply ival-fn (list-set is k ihi))))
-        (with-check-info (['split-argument k] ['ilo ilo] ['ihi ihi] ['iylo iylo] ['iyhi iyhi])
-          (check-ival-equals?
-           iy 
-           (parameterize ([bf-precision out-prec]) (ival-union iylo iyhi))))))
-    (when (or (ival-lo-fixed? iy) (ival-hi-fixed? iy))
-      (define iy* (parameterize ([bf-precision 128]) (apply ival-fn is)))
-      (check ival-refines? iy iy*))))
+  (with-check-info
+   (['intervals is] ['points xs] ['iy iy] ['y y] ['precs (list out-prec in-precs)])
+   (for ([k (in-naturals)] [i is] [x xs])
+     (define-values (ilo ihi) (ival-split i x))
+     (when (and ilo ihi)
+       (define iylo
+         (parameterize ([bf-precision out-prec])
+           (apply ival-fn (list-set is k ilo))))
+       (define iyhi
+         (parameterize ([bf-precision out-prec])
+           (apply ival-fn (list-set is k ihi))))
+       (with-check-info (['split-argument k] ['ilo ilo] ['ihi ihi] ['iylo iylo] ['iyhi iyhi])
+                        (check-ival-equals? iy
+                                            (parameterize ([bf-precision out-prec])
+                                              (ival-union iylo iyhi))))))
+   (when (or (ival-lo-fixed? iy) (ival-hi-fixed? iy))
+     (define iy*
+       (parameterize ([bf-precision 128])
+         (apply ival-fn is)))
+     (check ival-refines? iy iy*))))
 
 (define (run-tests)
   (check ival-contains? (ival-bool #f) #f)
@@ -282,12 +311,16 @@
     (for ([i (in-range num-tests)])
       (define pt (sample-bigfloat))
       (with-check-info (['point pt])
-        (check-ival-valid? (mk-ival pt))
-        (check ival-contains? (mk-ival pt) pt))))
+                       (check-ival-valid? (mk-ival pt))
+                       (check ival-contains? (mk-ival pt) pt))))
 
   (test-case "ival-error?"
-    (let* ([ival1 (mk-ival 1.bf)] [ival0 (mk-ival 0.bf)] [ivalboth (ival 0.bf 1.bf)]
-           [res1 (ival-div ival1 ival1)] [res2 (ival-div ival1 ival0)] [res3 (ival-div ival1 ivalboth)])
+    (let* ([ival1 (mk-ival 1.bf)]
+           [ival0 (mk-ival 0.bf)]
+           [ivalboth (ival 0.bf 1.bf)]
+           [res1 (ival-div ival1 ival1)]
+           [res2 (ival-div ival1 ival0)]
+           [res3 (ival-div ival1 ivalboth)])
       (check-ival-valid? (ival-error? res1))
       (check-ival-valid? (ival-error? res2))
       (check-ival-valid? (ival-error? res3))
@@ -299,17 +332,15 @@
   (define (sorted? list cmp)
     (cond
       [(<= (length list) 1) #t]
-      [else
-       (and (cmp (first list) (second list))
-            (sorted? (rest list) cmp))]))
-  
+      [else (and (cmp (first list) (second list)) (sorted? (rest list) cmp))]))
+
   (test-case "ival-sort"
     (for ([n (in-range num-tests)])
-         (let* ([input (for/list ([n (in-range (random 0 30))])
-                                 (sample-interval 'real))]
-                [output (ival-sort input bf<)])
-           (check-true (sorted? (map ival-lo output) bf<=))
-           (check-true (sorted? (map ival-hi output) bf<=)))))
+      (let* ([input (for/list ([n (in-range (random 0 30))])
+                      (sample-interval 'real))]
+             [output (ival-sort input bf<)])
+        (check-true (sorted? (map ival-lo output) bf<=))
+        (check-true (sorted? (map ival-hi output) bf<=)))))
 
   (test-case "ival-if"
     ;; Tests that movable conditions for if statements mean movable results
@@ -322,23 +353,23 @@
       (for ([n (in-range N)])
         (test-entry ival-fn fn args)))))
 
-(module+ test (run-tests))
+(module+ test
+  (run-tests))
 (module+ main
   (require racket/cmdline)
-  (command-line
-   #:args ([fname #f] [n (~a num-tests)])
-   (cond
-     [fname
-      (define entry
-        (findf (λ (entry) (equal? (~a (object-name (first entry))) (format "ival-~a" fname)))
-               function-table))
-      (match entry
-        [#f
-         (raise-user-error 'test.rkt "No function named ival-~a" fname)]
-        [(list ival-fn fn itypes otype)
-         (printf "~a on ~a inputs: " (object-name ival-fn) n)
-         (for ([n (in-range (string->number n))])
-           (test-entry ival-fn fn itypes)
-           (printf "."))
-         (newline)])]
-     [else (run-tests)])))
+  (command-line #:args ([fname #f] [n (~a num-tests)])
+                (cond
+                  [fname
+                   (define entry
+                     (findf (λ (entry)
+                              (equal? (~a (object-name (first entry))) (format "ival-~a" fname)))
+                            function-table))
+                   (match entry
+                     [#f (raise-user-error 'test.rkt "No function named ival-~a" fname)]
+                     [(list ival-fn fn itypes otype)
+                      (printf "~a on ~a inputs: " (object-name ival-fn) n)
+                      (for ([n (in-range (string->number n))])
+                        (test-entry ival-fn fn itypes)
+                        (printf "."))
+                      (newline)])]
+                  [else (run-tests)])))

--- a/time.rkt
+++ b/time.rkt
@@ -1,8 +1,15 @@
 #lang racket
 
-(require racket/math math/base math/flonum math/bigfloat racket/random profile)
+(require racket/math
+         math/base
+         math/flonum
+         math/bigfloat
+         racket/random
+         profile)
 (require json)
-(require "main.rkt" "test.rkt" "profile.rkt")
+(require "main.rkt"
+         "test.rkt"
+         "profile.rkt")
 
 (define sample-vals (make-parameter 5000))
 
@@ -84,7 +91,7 @@
             (~r (/ iv256 bf256) #:precision '(= 2) #:min-width 4)
             (~r iv4k #:precision '(= 3) #:min-width 8)
             (~r (/ iv4k bf4k) #:precision '(= 2) #:min-width 4))
-    
+
     (list (object-name ival-fn) iv256 (/ iv256 bf256) iv4k (/ iv4k bf4k))))
 
 (define (make-expression-table points test-id)
@@ -98,14 +105,13 @@
   (define count-u 0.0)
 
   (define table
-    (for/list ([rec (in-port read-json points)] 
+    (for/list ([rec (in-port read-json points)]
                [i (in-naturals)]
                #:break (and test-id (> i (string->number test-id)))
                #:unless (and test-id (not (equal? (~a i) test-id))))
       (when test-id
         (pretty-print (map read-from-string (hash-ref rec 'exprs))))
-      (match-define (list c-time v-num v-time i-num i-time u-num u-time)
-        (time-exprs (time-expr rec)))
+      (match-define (list c-time v-num v-time i-num i-time u-num u-time) (time-exprs (time-expr rec)))
       (set! total-c (+ total-c c-time))
       (set! total-v (+ total-v v-time))
       (set! count-v (+ count-v v-num))
@@ -121,11 +127,10 @@
               (~r i-time #:precision '(= 3) #:min-width 8)
               (~r u-time #:precision '(= 3) #:min-width 8))
       (list i t-time c-time v-num v-time i-num i-time u-num u-time)))
-  
+
   (define total-t (+ total-c total-v total-i total-u))
   (printf "\nTotal Time: ~as\n" (~r total-t #:precision '(= 3)))
-  (define footer
-    (list "Total" total-t total-c count-v total-v count-i total-i count-u total-u))
+  (define footer (list "Total" total-t total-c count-v total-v count-i total-i count-u total-u))
   (values table footer))
 
 (define (html-write port)
@@ -136,7 +141,9 @@
     (fprintf port "<link href='~a' rel='stylesheet' />" sortable-css)
     (fprintf port "<script src='profile.js' defer></script>")
     (fprintf port "<script src='~a' async defer></script>" sortable-js)
-    (fprintf port "<style>body { max-width: 100ex; margin: 3em auto; } td:nth-child(1n+2) { text-align: right; }</style>")))
+    (fprintf
+     port
+     "<style>body { max-width: 100ex; margin: 3em auto; } td:nth-child(1n+2) { text-align: right; }</style>")))
 
 (define current-heading #f)
 
@@ -147,7 +154,10 @@
     (fprintf port "<table class=sortable>")
     (fprintf port "<thead><tr>")
     (for ([col (in-list cols)])
-      (define name (match col [(list name _) name] [name name]))
+      (define name
+        (match col
+          [(list name _) name]
+          [name name]))
       (fprintf port "<th>~a</th>" name))
     (fprintf port "</tr></thead><tbody>")))
 
@@ -155,16 +165,16 @@
   (when port
     (fprintf port "<tr>")
     (for ([cell (in-list row)] [heading (in-list current-heading)])
-      (define unit (match heading [(list _ s) s] [_ ""]))
+      (define unit
+        (match heading
+          [(list _ s) s]
+          [_ ""]))
       (cond
-        [(and (number? cell) (zero? cell))
-         (fprintf port "<td></td>")]
-        [(integer? cell)
-         (fprintf port "<td>~a~a</td>" (~r cell #:group-sep " ") unit)]
+        [(and (number? cell) (zero? cell)) (fprintf port "<td></td>")]
+        [(integer? cell) (fprintf port "<td>~a~a</td>" (~r cell #:group-sep " ") unit)]
         [(real? cell)
          (fprintf port "<td data-sort=~a>~a~a</td>" cell (~r cell #:precision '(= 2)) unit)]
-        [else
-         (fprintf port "<td><code>~a</code></td>" cell)]))
+        [else (fprintf port "<td><code>~a</code></td>" cell)]))
     (fprintf port "</tr>")))
 
 (define (html-end-table port)
@@ -183,9 +193,7 @@
 
 (define (run test-id p)
   (define operation-table
-    (and
-     (or (not test-id) (not (string->number test-id)))
-     (make-operation-table test-id)))
+    (and (or (not test-id) (not (string->number test-id))) (make-operation-table test-id)))
   (define-values (expression-table expression-footer)
     (if (and p (or (not test-id) (string->number test-id)))
         (make-expression-table p test-id)
@@ -197,7 +205,7 @@
 
   (when operation-table
     (define cols
-      '("Operation" ("Time, 256b" "µs")  ("Slowdown" "×") ("Time, 4kb" "µs") ("Slowdown" "×")))
+      '("Operation" ("Time, 256b" "µs") ("Slowdown" "×") ("Time, 4kb" "µs") ("Slowdown" "×")))
     (html-write-table html-port "Operation timing" cols)
     (for ([row (in-list operation-table)])
       (html-write-row html-port row))
@@ -205,8 +213,14 @@
 
   (when expression-table
     (define cols
-      '("#" ("Total" "s") ("Compile" "s")
-            "Valid" ("(s)" "s") "Invalid" ("(s)" "s") "Unable" ("(s)" "s")))
+      '("#" ("Total" "s")
+            ("Compile" "s")
+            "Valid"
+            ("(s)" "s")
+            "Invalid"
+            ("(s)" "s")
+            "Unable"
+            ("(s)" "s")))
     (html-write-table html-port "Expression timing" cols)
     (for ([row (in-list expression-table)])
       (html-write-row html-port row))
@@ -219,26 +233,30 @@
 
 (define (profile-json-renderer profile-port)
   (lambda (p order)
-    (when profile-port (write-json (profile->json p) profile-port))))
+    (when profile-port
+      (write-json (profile->json p) profile-port))))
 
 (module+ main
   (require racket/cmdline)
   (define html-port #f)
   (define profile-port #f)
   (define n #f)
-  (command-line
-   #:once-each
-   [("--html") fn "Produce HTML output"
-               (set! html-port (open-output-file fn #:mode 'text #:exists 'replace))]
-   [("--profile") fn "Produce a JSON profile"
-                  (set! profile-port (open-output-file fn #:mode 'text #:exists 'replace))]
-   [("--id") ns "Run a single test"
-             (set! n ns)]
-   #:args ([points "infra/points.json"])
-   (match-define (list op-t ex-t ex-f)
-     (if profile-port
-         (profile #:order 'total #:delay 0.001 #:render (profile-json-renderer profile-port)
-          (run n (open-input-file points)))
-         (run n (open-input-file points))))
-   (when html-port
-     (generate-html html-port profile-port op-t ex-t ex-f))))
+  (command-line #:once-each [("--html")
+                             fn
+                             "Produce HTML output"
+                             (set! html-port (open-output-file fn #:mode 'text #:exists 'replace))]
+                [("--profile")
+                 fn
+                 "Produce a JSON profile"
+                 (set! profile-port (open-output-file fn #:mode 'text #:exists 'replace))]
+                [("--id") ns "Run a single test" (set! n ns)]
+                #:args ([points "infra/points.json"])
+                (match-define (list op-t ex-t ex-f)
+                  (if profile-port
+                      (profile #:order 'total
+                               #:delay 0.001
+                               #:render (profile-json-renderer profile-port)
+                               (run n (open-input-file points)))
+                      (run n (open-input-file points))))
+                (when html-port
+                  (generate-html html-port profile-port op-t ex-t ex-f))))

--- a/utils.rkt
+++ b/utils.rkt
@@ -1,18 +1,22 @@
 #lang racket/base
 
 (require "eval/machine.rkt")
-(require math/bigfloat math/flonum)
-(provide flonum-discretization boolean-discretization bf-discretization)
+(require math/bigfloat
+         math/flonum)
+(provide flonum-discretization
+         boolean-discretization
+         bf-discretization)
 
-(define flonum-discretization
-  (discretization 53 bigfloat->flonum (compose abs flonums-between)))
+(define flonum-discretization (discretization 53 bigfloat->flonum (compose abs flonums-between)))
 
-(define boolean-discretization
-  (discretization 53 values (lambda (x y) (if (eq? x y) 0 2))))
+(define boolean-discretization (discretization 53 values (lambda (x y) (if (eq? x y) 0 2))))
 
 (define (bf-discretization [precision #f])
   (define n (or precision (bf-precision)))
-  (discretization
-   n
-   (lambda (x) (parameterize ([bf-precision n]) (bfcopy x)))
-   (lambda (x y) (parameterize ([bf-precision n]) (abs (bigfloats-between x y))))))
+  (discretization n
+                  (lambda (x)
+                    (parameterize ([bf-precision n])
+                      (bfcopy x)))
+                  (lambda (x y)
+                    (parameterize ([bf-precision n])
+                      (abs (bigfloats-between x y))))))


### PR DESCRIPTION
This PR doesn't actually reformat anything yet (probably want everything merged and the repo quiet before we do that) but it adds a CI step that fails if `raco fmt` doesn't like your formatting. Which will allow us to enforce the formatting.