### PR TITLE
Add imperative interval operators that allocate less

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,132 +1,62 @@
 Interval Arithmetic for Real Computation
 ========================================
 
-Rival is an interval arithmetic library for Racket, intended for real
-computation. Rival supports Racket 7.0+ and depends only on the
-standard `math` library, including `math/bigfloat`.
+Rival is a library for evaluating real expressions to high precision.
+Rival supports Racket 8.0+ and depends only on the standard `math`
+library, including `math/bigfloat`.
 
 Using Rival
 -----------
 
-Rival's main data structure is the `ival`, which represents the set of
-extended real numbers between two points (inclusive both ends). Real
-numbers, for Rival, are represented by bigfloats. For example:
+Rival is easiest to use from its REPL:
 
-    > (require rival math/bigfloat)
-    > (ival 2.bf 3.bf)
-    (ival 2 3)
+    $ racket -l rival
+    > (eval (sin 1e100))
+    -0.3723761236612767
+    > (set precision 1000)
+    > (eval (sin 1e100))
+    -0.3723761236612766882620866955531642957...
+    > (set precision 100)
+    > (define (f x) (- (sin x) (- x (/ (pow x 3) 6))))
+    > (eval f 1e-100)
+    8.3333333333333333333333333333237e-503
 
-You can also easily create single-point intervals with `mk-ival`:
+The [full
+documentation](https://docs.racket-lang.org/rival/index.html)
+describes the Racket API and the underlying interval library.
 
-    > (ival 2.bf 2.bf)
-    (ival 2 2)
-    > (mk-ival 2.bf)
-    (ival 2 2)
+Features
+--------
 
-Rival provides interval implementations of all of the standard
-arithmetic functions:
+Rival provides a number of advanced features, which we believe makes
+Rival the state of the art real evaluation library:
 
-    > (ival-mult (ival 2.bf 3.bf) (ival 1.bf 2.bf))
-    (ival 2 6)
-    > (ival-sin (ival 2.bf 3.bf))
-    (ival 0.1411... 0.9092...)
+- Support for all `math.h` functions, including arithmetic,
+  trigonometric, power, remainder, rounding, and even gamma functions.
+- Support for comparisons, conditionals, and boolean operations
+  through boolean intervals
+- Sound handling of domain errors through error intervals
+- Fast and accurate mixed-precision assignments for evaluation
+- Correct rounding
+- Early exit using movability flags
+- Well-tested soundness and robustness
 
-Note intervals are always rounded outwards. Functions like `remainder`
-and `pow` match their counterparts in C's `math.h`.
-
-Control flow
+Contributing
 ------------
 
-Rival supports _boolean intervals_, where the bounds of the intervals
-are booleans instead of real numbers. This allows Rival to support
-comparisons, boolean operations, and conditionals:
+Please file issues and submit patches [on
+Github](https://github.com/herbie-fp/rival). All code should be
+formatted using `raco fmt`; you can set this up to happen on commit
+with:
 
-    > (ival-< (ival 1.bf 3.bf) (ival 2.bf 4.bf))
-    (ival #f #t)
-    > (ival-and (ival-< (ival 1.bf 3.bf) (ival 2.bf 4.bf))
-                (ival-bool #f))
-    (ival #f #f)
-    > (if (ival #f #t)
-          (ival 1.bf 2.bf)
-          (ival 3.bf 4.bf))
-    (ival 1.bf 4.bf)
+    make hook
 
-In addition, intervals contain _error intervals_ tracking whether any
-functions could/must be called outside their domain. These are
-accessible with `ival-err?` and `ival-err`. For example, since square
-root is defined only for positive values, calling it on `[-1, 1]`
-could, but doesn't have to, raise an error:
+Additionally, all code must pass the automated tests, which you can
+run with:
 
-    > (define i (ival-sqrt (ival -1.bf 1.bf)))
-    > i
-    (ival 0 1)
-    > (ival-err? i)
-    #t
-    > (ival err i)
-    #f
+    raco test test.rkt
 
-Meanwhile, calling it on `[-2, -1]` always produces an error:
+They also run in CI before merging. Finally, performance is a key
+metric for Rival; you can run the automated performance tests with:
 
-    > (define i (ival-sqrt (ival -2.bf -1.bf)))
-    > i
-    (ival +nan.bf +nan.bf)
-    > (ival-err? i)
-    #t
-    > (ival err i)
-    #t
-
-Movability
-----------
-
-Since Rival internally uses bigfloat computation, it is sensitive to
-bigfloat rounding. Intervals may shrink (though they cannot grow) when
-computed at a higher precision. However, in some cases it is known
-this will not occur, largely due to overflow. In those cases, the
-interval is marked fixed, or immovable:
-
-    > (ival-exp (mk-ival (bf 1e100)))
-    (ival ... +inf.bf)
-    > (ival-hi-fixed? (ival-exp (mk-ival (bf 1e100))))
-    #t
-
-Movability flags are propagated
-
-Rival's guarantees
-------------------
-
-Rival attempts to guarantee (and has random tests for) the following
-properties:
-
- + If `x ∈ I`, `f(x) ∈ f(I)`,
-   where both functions are computed at the same biginterval precision.
- + If `f(I) = [l, h]`, then `∃ x ∈ I, f(x) = l` (if `f` rounds down),
-   and likewise for `h`.
-
-Completeness may be violated in edge cases for complex functions such
-as `fmod` and `pow`.
-
-Error flags also aim to be sound and complete:
-
- + If `f(x)` raises an error and `x ∈ I`, then `err?(f(I))`.
- + If `err?(f(I))`, then `∃ x ∈ I` such that `f(x)` raises an error
-
-However, Rival sometimes idiosyncratically interprets some error
-conditions as valid. For example, `sin(+inf.bf)` is interpreted as the
-_interval_ `[-1, 1]` instead of as an error condition; this impacts
-both soundness and completeness.
-
-Finally movability flags aim at soundness, though not yet completeness:
-
- + If `f(I).hi.fixed?` at a precision `p`,
-   then `f(I).hi` is the same at all precisions `q > p`
-   
-Besides functional correctness, Rival guarantees termination for each
-operation and error-freedom for correctly-invoked operations. (Its
-contracts are not yet strong enough to prevent ill-typed invocations.)
-
-Speed is fairly good, with attention paid to avoid unnecessary
-bigfloat computations.
-
-Please report any failures of any of the above properties as bugs.
-
-
+    racket -y time.rkt

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -226,21 +226,6 @@
     (define max-prec (vector-ref vprecs-max (- n varc))) ; upper precision bound given from parent
     (define min-prec (vector-ref vprecs-min (- n varc))) ; lower precision bound given from parent
 
-    ; Final precision assignment based on the upper bound
-    (define final-precision
-      (min (max (+ max-prec (vector-ref vstart-precs (- n varc))) (*rival-min-precision*))
-           (*rival-max-precision*)))
-    (vector-set! vprecs-max (- n varc) final-precision)
-
-    ; Early stopping
-    (match (*lower-bound-early-stopping*)
-      [#t
-       (when (>= min-prec (*rival-max-precision*))
-         (*sampling-iteration* (*rival-max-iterations*)))]
-      [#f
-       (when (equal? final-precision (*rival-max-precision*))
-         (*sampling-iteration* (*rival-max-iterations*)))])
-
     ; Precision propogation for each tail instruction
     (define ampl-bounds (get-bounds op output srcs)) ; amplification bounds for children instructions
     (for ([x (in-list tail-registers)]
@@ -256,4 +241,19 @@
       ; Lower precision bound propogation
       (vector-set! vprecs-min
                    (- x varc)
-                   (max (vector-ref vprecs-min (- x varc)) (+ min-prec (max 0 lo-bound)))))))
+                   (max (vector-ref vprecs-min (- x varc)) (+ min-prec (max 0 lo-bound)))))
+
+    ; Final precision assignment based on the upper bound
+    (define final-precision
+      (min (max (+ max-prec (vector-ref vstart-precs (- n varc))) (*rival-min-precision*))
+           (*rival-max-precision*)))
+    (vector-set! vprecs-max (- n varc) final-precision)
+
+    ; Early stopping
+    (match (*lower-bound-early-stopping*)
+      [#t
+       (when (>= min-prec (*rival-max-precision*))
+         (*sampling-iteration* (*rival-max-iterations*)))]
+      [#f
+       (when (equal? final-precision (*rival-max-precision*))
+         (*sampling-iteration* (*rival-max-iterations*)))])))

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -188,6 +188,16 @@
      (define x (first srcs))
      (list (quotient (logspan x) 2))]
 
+    [(ival-add! ival-sub!)
+     ; k = 1: maxlog(x) - minlog(z)
+     ; k = 2: maxlog(y) - minlog(z)
+     (define x (second srcs))
+     (define y (third srcs))
+
+     (list 0
+           (- (maxlog x) (minlog z)) ; exponent per x
+           (- (maxlog y) (minlog z)))] ; exponent per y
+
     [(ival-add ival-sub)
      ; k = 1: maxlog(x) - minlog(z)
      ; k = 2: maxlog(y) - minlog(z)

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -275,12 +275,13 @@
   (define registers (make-vector register-count))
 
   (define instructions
-    (for/vector #:length ivec-length ([node (in-vector nodes num-vars)] [n (in-naturals)])
+    (for/vector #:length ivec-length
+                ([node (in-vector nodes num-vars)]
+                 [n (in-naturals num-vars)])
       (fn->ival-fn node
                    (lambda ()
-                     (define out (new-ival))
-                     (vector-set! registers (+ num-vars n) out)
-                     (+ num-vars n)))))
+                     (vector-set! registers n (new-ival))
+                     n))))
 
   (define repeats (make-vector ivec-length #f)) ; flags whether an op should be evaluated
   (define precisions (make-vector ivec-length)) ; vector that stores working precisions

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -225,8 +225,8 @@
 
         [(list '+ x y) (list ival-add! (output-register!) x y)]
         [(list '- x y) (list ival-sub! (output-register!) x y)]
-        [(list '* x y) (list ival-mult x y)]
-        [(list '/ x y) (list ival-div x y)]
+        [(list '* x y) (list ival-mult! (output-register!) x y)]
+        [(list '/ x y) (list ival-div! (output-register!) x y)]
         [(list 'atan2 x y) (list ival-atan2 x y)]
         [(list 'copysign x y) (list ival-copysign x y)]
         [(list 'hypot x y) (list ival-hypot x y)]

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -96,6 +96,13 @@
      (list (cons (logspan y) 0) ; bounds per x
            (cons (logspan x) 0))] ; bounds per y
 
+    [(ival-mult!)
+     ; Same as above, ignoring output register
+     (match-define (list _ x y) srcs)
+     (list (cons 0 0) ; Ignore output register
+           (cons (logspan y) 0) ; bounds per x
+           (cons (logspan x) 0))] ; bounds per y
+
     [(ival-div)
      ; Γ[/]'x     = 1
      ; ↑ampl[/]'x = logspan(y)
@@ -107,6 +114,12 @@
      (define x (first srcs))
      (define y (second srcs))
      (list (cons (logspan y) 0) ; bounds per x
+           (cons (+ (logspan x) (* 2 (logspan y))) 0))] ; bounds per y
+
+    [(ival-div!)
+     (match-define (list _ x y) srcs)
+     (list (cons 0 0)
+           (cons (logspan y) 0) ; bounds per x
            (cons (+ (logspan x) (* 2 (logspan y))) 0))] ; bounds per y
 
     [(ival-sqrt ival-cbrt)
@@ -137,6 +150,19 @@
                (cons (- (maxlog y) (minlog z))
                      (- (minlog y #:less-slack #t) (maxlog z #:less-slack #t)))) ; bounds per y
          (list (cons (- (maxlog x) (minlog z)) 0) ; bounds per x
+               (cons (- (maxlog y) (minlog z)) 0)))] ; bounds per y
+
+    [(ival-add! ival-sub!)
+     (match-define (list _ x y) srcs)
+
+     (if (*lower-bound-early-stopping*)
+         (list (cons 0 0)
+               (cons (- (maxlog x) (minlog z))
+                     (- (minlog x #:less-slack #t) (maxlog z #:less-slack #t))) ; bounds per x
+               (cons (- (maxlog y) (minlog z))
+                     (- (minlog y #:less-slack #t) (maxlog z #:less-slack #t)))) ; bounds per y
+         (list (cons 0 0)
+               (cons (- (maxlog x) (minlog z)) 0) ; bounds per x
                (cons (- (maxlog y) (minlog z)) 0)))] ; bounds per y
 
     [(ival-pow)

--- a/infra/run-baseline.rkt
+++ b/infra/run-baseline.rkt
@@ -152,9 +152,9 @@
   (define register-count (vector-length nodes))
   (define registers (make-vector register-count))
   (define precisions
-    (make-vector (vector-length instructions))) ; vector that stores working precisions
-  (define repeats (make-vector (vector-length instructions)))
-  (define hint (make-vector (vector-length instructions) #t))
+    (make-vector (- register-count num-vars))) ; vector that stores working precisions
+  (define repeats (make-vector (- register-count num-vars)))
+  (define hint (make-vector (- register-count num-vars) #t))
 
   (define instructions
     (for/vector #:length (- register-count num-vars)

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -58,9 +58,12 @@
 
 (define mpfr-set-prec! (get-mpfr-fun 'mpfr_set_prec (_fun _mpfr-pointer _prec_t -> _void)))
 
-(define mpfr-clear! (get-mpfr-fun 'mpfr_clear (_fun _mpfr-pointer -> _void)))
-
 (define mpfr-init2! (get-mpfr-fun 'mpfr_init2 (_fun _mpfr-pointer _prec_t -> _void)))
+
+(define (mpfr-new! prec)
+  (define bf (make-mpfr 0 0 0 #f))
+  (mpfr-init2! bf prec)
+  bf)
 
 (define (bfremainder x mod)
   (define out (bf 0))
@@ -221,5 +224,4 @@
          mpfr-mul!
          mpfr-div!
          mpfr-set-prec!
-         mpfr-clear!
-         mpfr-init2!)
+         mpfr-new!)

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -60,6 +60,8 @@
 
 (define mpfr-init2! (get-mpfr-fun 'mpfr_init2 (_fun _mpfr-pointer _prec_t -> _void)))
 
+(define mpfr-set! (get-mpfr-fun 'mpfr_set (_fun _mpfr-pointer _mpfr-pointer _rnd_t -> _void)))
+
 (define (mpfr-new! prec)
   (define bf (make-mpfr 0 0 0 #f))
   (mpfr-init2! bf prec)
@@ -224,4 +226,5 @@
          mpfr-mul!
          mpfr-div!
          mpfr-set-prec!
-         mpfr-new!)
+         mpfr-new!
+         mpfr-set!)

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -56,6 +56,12 @@
 (define mpfr-remainder!
   (get-mpfr-fun 'mpfr_remainder (_fun _mpfr-pointer _mpfr-pointer _mpfr-pointer _rnd_t -> _int)))
 
+(define mpfr-set-prec! (get-mpfr-fun 'mpfr_set_prec (_fun _mpfr-pointer _prec_t -> _void)))
+
+(define mpfr-clear! (get-mpfr-fun 'mpfr_clear (_fun _mpfr-pointer -> _void)))
+
+(define mpfr-init2! (get-mpfr-fun 'mpfr_init2 (_fun _mpfr-pointer _prec_t -> _void)))
+
 (define (bfremainder x mod)
   (define out (bf 0))
   (mpfr-remainder! out x mod (bf-rounding-mode))
@@ -213,4 +219,7 @@
          mpfr-add!
          mpfr-sub!
          mpfr-mul!
-         mpfr-div!)
+         mpfr-div!
+         mpfr-set-prec!
+         mpfr-clear!
+         mpfr-init2!)

--- a/ops/all.rkt
+++ b/ops/all.rkt
@@ -23,7 +23,9 @@
          ival-sub!
          ival-neg
          ival-mult
+         ival-mult!
          ival-div
+         ival-div!
          ival-fma
          ival-fabs
          ival-sqrt

--- a/ops/all.rkt
+++ b/ops/all.rkt
@@ -18,7 +18,9 @@
          ival-e
          ival-bool
          ival-add
+         ival-add!
          ival-sub
+         ival-sub!
          ival-neg
          ival-mult
          ival-div

--- a/ops/arith.rkt
+++ b/ops/arith.rkt
@@ -25,7 +25,7 @@
   (match-define (endpoint a a!) a-endpoint)
   (match-define (endpoint b b!) b-endpoint)
   (mpfr-set-prec! out (bf-precision))
-  (define exact? (= (mpfr-fn! out a b rnd) 0))
+  (define exact? (= 0 (mpfr-fn! out a b rnd)))
   (endpoint out (or (and a! b! exact?) (and a! (bfinfinite? a)) (and b! (bfinfinite? b)))))
 
 (define (ival-add! out x y)
@@ -106,7 +106,7 @@
   (match-define (endpoint a a!) a-endpoint)
   (match-define (endpoint b b!) b-endpoint)
   (mpfr-set-prec! out (bf-precision))
-  (define exact? (mpfr-div! out a b (bf-rounding-mode)))
+  (define exact? (= 0 (mpfr-div! out a b (bf-rounding-mode))))
   (endpoint out
             (or (and a! b! exact?)
                 (and a! (bfzero? a))

--- a/ops/arith.rkt
+++ b/ops/arith.rkt
@@ -59,7 +59,7 @@
   (define exact?
     (cond
       [(or a0 b0)
-       (bfcopy out 0.bf)
+       (mpfr-set! out 0.bf 'nearest)
        #t]
       [else (= 0 (mpfr-mul! out a b (bf-rounding-mode)))]))
   (endpoint out
@@ -73,6 +73,8 @@
   (define out (new-ival))
   (ival-mult! out x y)
   out)
+
+(define extra-mult-ival (new-ival))
 
 (define (ival-mult! out x y)
   (match-define (ival xlo xhi xerr? xerr) x)
@@ -101,9 +103,9 @@
     ;; however, both branches compute possible lo/hi's to min/max together
     [(0 0)
      (match-define (ival (endpoint lo lo!) (endpoint hi hi!) err? err)
-       (ival-union (mkmult (new-ival) xhi ylo xlo ylo) (mkmult out xlo yhi xhi yhi)))
-     (mpfr-set! (ival-lo-val out) lo)
-     (mpfr-set! (ival-hi-val out) hi)
+       (ival-union (mkmult extra-mult-ival xhi ylo xlo ylo) (mkmult out xlo yhi xhi yhi)))
+     (mpfr-set! (ival-lo-val out) lo 'down) ; should be exact
+     (mpfr-set! (ival-hi-val out) hi 'up) ; should be exact
      (ival (endpoint (ival-lo-val out) lo!) (endpoint (ival-hi-val out) hi!) err? err)]))
 
 (define (epdiv! out a-endpoint b-endpoint a-class)

--- a/ops/arith.rkt
+++ b/ops/arith.rkt
@@ -134,7 +134,9 @@
        (or (and (endpoint-immovable? ylo) (bfzero? (endpoint-val ylo)))
            (and (endpoint-immovable? yhi) (bfzero? (endpoint-val yhi)))
            (and (endpoint-immovable? ylo) (endpoint-immovable? yhi))))
-     (ival (endpoint -inf.bf immovable?) (endpoint +inf.bf immovable?) err? err)]
+     (mpfr-set! rlo -inf.bf 'down)
+     (mpfr-set! rhi +inf.bf 'up)
+     (ival (endpoint rlo immovable?) (endpoint rhi immovable?) err? err)]
     [(1 1) (mkdiv xlo yhi xhi ylo)]
     [(1 -1) (mkdiv xhi yhi xlo ylo)]
     [(-1 1) (mkdiv xlo ylo xhi yhi)]

--- a/ops/arith.rkt
+++ b/ops/arith.rkt
@@ -99,7 +99,12 @@
     [(0 -1) (mkmult out xhi ylo xlo ylo)]
     ;; Here, the two branches of the union are meaningless on their own;
     ;; however, both branches compute possible lo/hi's to min/max together
-    [(0 0) (ival-union (mkmult (new-ival) xhi ylo xlo ylo) (mkmult out xlo yhi xhi yhi))]))
+    [(0 0)
+     (match-define (ival (endpoint lo lo!) (endpoint hi hi!) err? err)
+       (ival-union (mkmult (new-ival) xhi ylo xlo ylo) (mkmult out xlo yhi xhi yhi)))
+     (mpfr-set! (ival-lo-val out) lo)
+     (mpfr-set! (ival-hi-val out) hi)
+     (ival (endpoint (ival-lo-val out) lo!) (endpoint (ival-hi-val out) hi!) err? err)]))
 
 (define (epdiv! out a-endpoint b-endpoint a-class)
   (match-define (endpoint a a!) a-endpoint)

--- a/ops/arith.rkt
+++ b/ops/arith.rkt
@@ -35,9 +35,7 @@
         (or (ival-err x) (ival-err y))))
 
 (define (ival-add x y)
-  (define out (new-ival))
-  (ival-add! out x y)
-  out)
+  (ival-add! (new-ival) x y))
 
 (define (ival-sub! out x y)
   (ival (eplinear! (ival-lo-val out) mpfr-sub! (ival-lo x) (ival-hi y) 'down)
@@ -46,9 +44,7 @@
         (or (ival-err x) (ival-err y))))
 
 (define (ival-sub x y)
-  (define out (new-ival))
-  (ival-sub! out x y)
-  out)
+  (ival-sub! (new-ival) x y))
 
 (define (epmul! out a-endpoint b-endpoint a-class b-class)
   (match-define (endpoint a a!) a-endpoint)
@@ -70,9 +66,7 @@
                 (and b! (bfinfinite? b) (not (= a-class 0))))))
 
 (define (ival-mult x y)
-  (define out (new-ival))
-  (ival-mult! out x y)
-  out)
+  (ival-mult! (new-ival) x y))
 
 (define extra-mult-ival (new-ival))
 
@@ -111,6 +105,7 @@
 (define (epdiv! out a-endpoint b-endpoint a-class)
   (match-define (endpoint a a!) a-endpoint)
   (match-define (endpoint b b!) b-endpoint)
+  (mpfr-set-prec! out (bf-precision))
   (define exact? (mpfr-div! out a b (bf-rounding-mode)))
   (endpoint out
             (or (and a! b! exact?)
@@ -148,9 +143,7 @@
     [(0 -1) (mkdiv xhi yhi xlo yhi)]))
 
 (define (ival-div x y)
-  (define out (new-ival))
-  (ival-div! out x y)
-  out)
+  (ival-div! (new-ival) x y))
 
 (define (ival-fma a b c)
   (ival-add (ival-mult a b) c))

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -120,10 +120,9 @@
 
 (define (new-ival)
   ; Warning, leaks memory unless `mpfr-clear!` called eventually
-  (define out (ival (endpoint (bf 0) #f) (endpoint (bf 0) #f) #f #f))
-  (mpfr-init2! (ival-lo-val out) (bf-precision))
-  (mpfr-init2! (ival-hi-val out) (bf-precision))
-  out)
+  (define bf1 (mpfr-new! (bf-precision)))
+  (define bf2 (mpfr-new! (bf-precision)))
+  (ival (endpoint bf1 #f) (endpoint bf2 #f) #f #f))
 
 (define (mk-big-ival x y)
   (cond

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -12,6 +12,7 @@
          classify-ival
          classify-ival-strict
          mk-big-ival
+         new-ival
          ival-exact-fabs
          ival-maybe
          epfn
@@ -116,6 +117,13 @@
   (endpoint-immovable? (ival-lo ival)))
 (define (ival-hi-fixed? ival)
   (endpoint-immovable? (ival-hi ival)))
+
+(define (new-ival)
+  ; Warning, leaks memory unless `mpfr-clear!` called eventually
+  (define out (ival (endpoint (bf 0) #f) (endpoint (bf 0) #f) #f #f))
+  (mpfr-init2! (ival-lo-val out) (bf-precision))
+  (mpfr-init2! (ival-hi-val out) (bf-precision))
+  out)
 
 (define (mk-big-ival x y)
   (cond


### PR DESCRIPTION
This PR adds the `ival-add!`, `ival-sub!`, `ival-mult!`, and `ival-div!` operators, which are in three-argument form. These have a kind-of weird API: they still _return_ the output interval, but they are allowed to use their first argument as pre-allocated space when doing so. In any case, the point of this all is that we can avoid allocating in the hot loop, which should make not only later but also first iterations faster.

The arithmetic operators are by far the majority of the run time, so handling just these four is sensible. In fact, multiplication is 30% of run time on its own. (Note that multiplication has a case where it constructs two different intervals and unions them; this still requires some allocation.)

A big current flaw with this PR is that the pre-allocated values are never garbage-collected, resulting in a memory leak. That has to be fixed before we merge this PR.