### PR TITLE
Don't freak out when the difference between two values is exactly 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,5 @@ nightly:
 	bash infra/nightly.sh perf
 	nightly-results publish report/
 
-hook:
-	echo "#!/bin/sh" >.git/hooks/pre-commit
-	echo "raco fmt -i \$$(find . -name '*.rkt')" >>.git/hooks/pre-commit
+fmt:
+	@raco fmt -i $(shell find infra/ ops/ eval/ ./ -name '*.rkt')

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -138,6 +138,7 @@
   (define hi (ival-hi x))
   (cond
     ; x = [0.bf, ...]
+    [(and (bfzero? lo) (bfzero? hi)) (get-slack)]
     [(bfzero? lo)
      (if (bfinfinite? hi)
          (- (get-slack))


### PR DESCRIPTION
This PR fixes the `minlog` function so that `minlog([0, 0])` doesn't accidentally assign an enormous precision for no reason.