### PR TITLE
No iteration limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ doc/
 infra/points.json
 out.html
 profile.json
+*~
+

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -92,13 +92,13 @@
 
     ; Add slack to overflows/underflows
     (when (and (bigfloat? (ival-lo output))
-               (or (and (ival-lo-fixed? output)
-                        (or (bfinfinite? (ival-lo output)) (bfzero? (ival-lo output))))
-                   (and (ival-hi-fixed? output)
-                        (or (bfinfinite? (ival-hi output)) (bfzero? (ival-hi output))))))
+               (or (bfinfinite? (ival-lo output))
+                   (bfzero? (ival-lo output))
+                   (bfinfinite? (ival-hi output))
+                   (bfzero? (ival-hi output))))
       (set! final-precision (+ final-precision (get-slack))))
-
     (set! final-precision (min final-precision (*rival-max-precision*)))
+
     (vector-set! vprecs-max (- n varc) final-precision)
 
     ; Early stopping based on higher bound

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -22,7 +22,6 @@
   (define vprecs (rival-machine-precisions machine))
   (define vstart-precs (rival-machine-incremental-precisions machine))
   (define current-iter (rival-machine-iteration machine))
-  (define bumps (rival-machine-bumps machine))
 
   (define varc (vector-length args))
   (define vprecs-new (make-vector (vector-length ivec) 0)) ; new vprecs vector
@@ -74,17 +73,10 @@
   ; Step 4. Copying new precisions into vprecs
   (vector-copy! vprecs 0 vprecs-new)
 
-  ; Step 5. If precisions have not changed but the point didn't converge. A problem exists - add slack to every op
+  ; Step 5. If precisions have not changed but the point didn't converge.
+  ; Likely the max precision has been reached - exit
   (unless any-false?
-    (set-rival-machine-bumps! machine (add1 bumps))
-    (define slack (get-slack))
-    (for ([prec (in-vector vprecs)]
-          [n (in-range (vector-length vprecs))])
-      (define prec* (min (*rival-max-precision*) (+ prec slack)))
-      (when (equal? prec* (*rival-max-precision*))
-        (*last-iteration* #t))
-      (vector-set! vprecs n prec*))
-    (vector-fill! vrepeats #f)))
+    (*last-iteration* #t)))
 
 ; This function goes through ivec and vregs and calculates (+ ampls base-precisions) for each operator in ivec
 ; Roughly speaking, the upper precision bound is calculated as:

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -91,7 +91,7 @@
 
     ; Early stopping based on higher bound
     (when (and (not (*lower-bound-early-stopping*)) (equal? final-precision (*rival-max-precision*)))
-      (*sampling-iteration* (*rival-max-iterations*)))
+      (*last-iteration* #t))
 
     ; Precision propogation for each tail instruction
     (define ampl-bounds (get-bounds op output srcs)) ; amplification bounds for children instructions
@@ -107,4 +107,4 @@
 
       ; Early stopping based on lower bound
       (when (and (*lower-bound-early-stopping*) (>= lo-bound (*rival-max-precision*)))
-        (*sampling-iteration* (*rival-max-iterations*))))))
+        (*last-iteration* #t)))))

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -57,6 +57,7 @@
   ; Step 3. Repeating precisions check + Assigning if a operation should be computed again at all
   ; vrepeats[i] = #t if the node has the same precision as an iteration before and children have #t flag as well
   ; vrepeats[i] = #f if the node doesn't have the same precision as an iteration before or at least one child has #f flag
+  (define any-false? #f)
   (for ([instr (in-vector ivec)]
         [useful? (in-vector vuseful)]
         [prec-old (in-vector (if (equal? 1 current-iter) vstart-precs vprecs))]
@@ -67,10 +68,23 @@
       (or (not useful?)
           (and (<= prec-new prec-old)
                (andmap (lambda (x) (or (< x varc) (vector-ref vrepeats (- x varc)))) (cdr instr)))))
+    (set! any-false? (or any-false? (not repeat)))
     (vector-set! vrepeats n repeat))
 
   ; Step 4. Copying new precisions into vprecs
-  (vector-copy! vprecs 0 vprecs-new))
+  (vector-copy! vprecs 0 vprecs-new)
+
+  ; Step 5. If precisions have not changed but the point didn't converge. A problem exists - add slack to every op
+  (unless any-false?
+    (set-rival-machine-bumps! machine (add1 bumps))
+    (define slack (get-slack))
+    (for ([prec (in-vector vprecs)]
+          [n (in-range (vector-length vprecs))])
+      (define prec* (min (*rival-max-precision*) (+ prec slack)))
+      (when (equal? prec* (*rival-max-precision*))
+        (*last-iteration* #t))
+      (vector-set! vprecs n prec*))
+    (vector-fill! vrepeats #f)))
 
 ; This function goes through ivec and vregs and calculates (+ ampls base-precisions) for each operator in ivec
 ; Roughly speaking, the upper precision bound is calculated as:

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -287,7 +287,6 @@
                  initial-precision
                  0
                  0
-                 0
                  (make-vector (*rival-profile-executions*))
                  (make-vector (*rival-profile-executions*))
                  (make-flvector (*rival-profile-executions*))

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -29,7 +29,6 @@
                    output-distance
                    initial-precision
                    [iteration #:mutable]
-                   [bumps #:mutable]
                    [profile-ptr #:mutable]
                    profile-instruction
                    profile-number

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -14,7 +14,7 @@
 (define *rival-max-precision* (make-parameter 10000))
 (define *rival-min-precision* (make-parameter 20))
 (define *rival-profile-executions* (make-parameter 1000))
-(define *lower-bound-early-stopping* (make-parameter #f))
+(define *lower-bound-early-stopping* (make-parameter #t))
 
 (struct discretization (target convert distance))
 

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -4,16 +4,15 @@
          (struct-out rival-machine)
          *rival-max-precision*
          *rival-min-precision*
-         *rival-max-iterations*
          *rival-profile-executions*
          *ampl-tuning-bits*
+         *last-iteration*
          *sampling-iteration*
          *lower-bound-early-stopping*
          *base-tuning-precision*)
 
 (define *rival-max-precision* (make-parameter 10000))
 (define *rival-min-precision* (make-parameter 20))
-(define *rival-max-iterations* (make-parameter 5))
 (define *rival-profile-executions* (make-parameter 1000))
 (define *lower-bound-early-stopping* (make-parameter #f))
 
@@ -39,4 +38,5 @@
 
 (define *ampl-tuning-bits* (make-parameter 5))
 (define *sampling-iteration* (make-parameter 0))
+(define *last-iteration* (make-parameter #f))
 (define *base-tuning-precision* (make-parameter 10))

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -67,6 +67,9 @@
     (define-values (good? done? bad? stuck? fvec)
       (parameterize ([*sampling-iteration* iter]
                      [ground-truth-require-convergence #t])
+        (when (> (*sampling-iteration*) 10)
+          (println pt)
+          (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt)))
         (rival-machine-full machine (vector-map ival-real pt))))
     (cond
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -43,7 +43,6 @@
   (match param
     ['instructions (vector-length (rival-machine-instructions machine))]
     ['iterations (rival-machine-iteration machine)]
-    ['bumps (rival-machine-bumps machine)]
     ['executions
      (define profile-ptr (rival-machine-profile-ptr machine))
      (define profile-instruction (rival-machine-profile-instruction machine))
@@ -63,7 +62,6 @@
 
 (define (rival-apply machine pt)
   (define discs (rival-machine-discs machine))
-  (set-rival-machine-bumps! machine 0)
   (*last-iteration* #f)
 
   (let loop ([iter 0])

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -15,7 +15,6 @@
          (struct-out exn:rival:unsamplable)
          (struct-out discretization)
          *rival-max-precision*
-         *rival-max-iterations*
          *rival-use-shorthands*
          *rival-name-constants*
          rival-profile
@@ -27,12 +26,9 @@
 (define (rival-machine-full machine inputs)
   (set-rival-machine-iteration! machine (*sampling-iteration*))
   (rival-machine-adjust machine)
-  (cond
-    [(>= (*sampling-iteration*) (*rival-max-iterations*)) (values #f #f #f #t #f)]
-    [else
-     (rival-machine-load machine inputs)
-     (rival-machine-run machine)
-     (rival-machine-return machine)]))
+  (rival-machine-load machine inputs)
+  (rival-machine-run machine)
+  (rival-machine-return machine))
 
 (struct exn:rival exn:fail ())
 (struct exn:rival:invalid exn:rival (pt))
@@ -65,6 +61,8 @@
 (define (rival-apply machine pt)
   (define discs (rival-machine-discs machine))
   (set-rival-machine-bumps! machine 0)
+  (*last-iteration* #f)
+
   (let loop ([iter 0])
     (define-values (good? done? bad? stuck? fvec)
       (parameterize ([*sampling-iteration* iter]
@@ -74,7 +72,7 @@
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
       [done? fvec]
       [stuck? (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
-      [(>= iter (*rival-max-iterations*))
+      [(*last-iteration*)
        (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [else (loop (+ 1 iter))])))
 

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -26,9 +26,12 @@
 (define (rival-machine-full machine inputs)
   (set-rival-machine-iteration! machine (*sampling-iteration*))
   (rival-machine-adjust machine)
-  (rival-machine-load machine inputs)
-  (rival-machine-run machine)
-  (rival-machine-return machine))
+  (cond
+    [(*last-iteration*) (values #f #f #f #t #f)]
+    [else
+     (rival-machine-load machine inputs)
+     (rival-machine-run machine)
+     (rival-machine-return machine)]))
 
 (struct exn:rival exn:fail ())
 (struct exn:rival:invalid exn:rival (pt))
@@ -75,8 +78,6 @@
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
       [done? fvec]
       [stuck? (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
-      [(*last-iteration*)
-       (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [else (loop (+ 1 iter))])))
 
 (define (rival-analyze machine rect)

--- a/eval/run.rkt
+++ b/eval/run.rkt
@@ -70,7 +70,6 @@
   (define vregs (rival-machine-registers machine))
   (define rootvec (rival-machine-outputs machine))
   (define slackvec (rival-machine-output-distance machine))
-  (define ovec (make-vector (vector-length rootvec)))
   (define good? #t)
   (define done? #t)
   (define bad? #f)

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -164,14 +164,16 @@
            0))
 
      (if (*lower-bound-early-stopping*)
-         (list (cons (+ (maxlog y) (logspan x) (logspan z) x-slack)
+         (list (cons (max (+ (maxlog y) (logspan x) (logspan z) x-slack) x-slack)
                      (minlog y #:no-slack #t)) ; bounds per x
-               (cons (+ (maxlog y) (max (abs (maxlog x)) (abs (minlog x))) (logspan z) y-slack)
+               (cons (max (+ (maxlog y) (max (abs (maxlog x)) (abs (minlog x))) (logspan z) y-slack)
+                          y-slack)
                      (if (> (minlog x) 2)
                          (minlog y #:no-slack #t)
                          0))) ; bounds per y
-         (list (cons (+ (maxlog y) (logspan x) (logspan z) x-slack) 0) ; bounds per x
-               (cons (+ (maxlog y) (max (abs (maxlog x)) (abs (minlog x))) (logspan z) y-slack)
+         (list (cons (max (+ (maxlog y) (logspan x) (logspan z) x-slack) x-slack) 0) ; bounds per x
+               (cons (max (+ (maxlog y) (max (abs (maxlog x)) (abs (minlog x))) (logspan z) y-slack)
+                          y-slack)
                      0)))] ; bounds per y
 
     [(ival-exp ival-exp2)
@@ -297,7 +299,7 @@
            0))
 
      (list (cons (- (maxlog x) (minlog z)) 0) ; bounds per x
-           (cons (max (+ (- (maxlog x) (minlog z)) slack) slack) 0))] ; bounds per y
+           (cons (+ (- (maxlog x) (minlog z)) slack) 0))] ; bounds per y
 
     ; Currently log1p has a very poor approximation
     [(ival-log1p)
@@ -310,7 +312,7 @@
      (define xlo (ival-lo x))
 
      (list (if (or (equal? (mpfr-sign xlo) -1) (equal? (mpfr-sign xhi) -1))
-               (cons (max (+ (- (maxlog x) (minlog z)) (get-slack)) (get-slack)) 0)
+               (cons (+ (- (maxlog x) (minlog z)) (get-slack)) 0)
                (cons (- (maxlog x) (minlog z)) 0)))]
 
     ; Currently expm1 has a very poor solution for negative values
@@ -362,7 +364,7 @@
      ; ↓ampl[acosh]'x = 0
      (define z-exp (minlog z))
      (list (if (< z-exp 2) ; when acosh(x) < 1
-               (cons (max (- (get-slack) z-exp) (get-slack)) 0)
+               (cons (- (get-slack) z-exp) 0)
                (cons 0 0)))]
 
     [(ival-pow2)

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -14,11 +14,7 @@
 (define (get-slack [iter (*sampling-iteration*)])
   (match iter
     [0 0]
-    [1 512]
-    [2 1024]
-    [3 2048]
-    [4 4096]
-    [5 8192]))
+    [_ (* (expt 2 (- iter 1)) 512)]))
 
 (define (crosses-zero? x)
   (not (equal? (mpfr-sign (ival-lo x)) (mpfr-sign (ival-hi x)))))

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -163,16 +163,19 @@
            (get-slack)
            0))
 
+     (define minlog-x (minlog x))
+     (define maxlog-x (maxlog x))
+
      (if (*lower-bound-early-stopping*)
          (list (cons (max (+ (maxlog y) (logspan x) (logspan z) x-slack) x-slack)
                      (minlog y #:no-slack #t)) ; bounds per x
-               (cons (max (+ (maxlog y) (max (abs (maxlog x)) (abs (minlog x))) (logspan z) y-slack)
+               (cons (max (+ (maxlog y) (max (abs maxlog-x) (abs minlog-x)) (logspan z) y-slack)
                           y-slack)
-                     (if (> (minlog x) 2)
-                         (minlog y #:no-slack #t)
-                         0))) ; bounds per y
+                     (cond
+                       [(zero? (min (abs maxlog-x) (abs minlog-x))) 0]
+                       [else (minlog y #:no-slack #t)]))) ; bounds per y
          (list (cons (max (+ (maxlog y) (logspan x) (logspan z) x-slack) x-slack) 0) ; bounds per x
-               (cons (max (+ (maxlog y) (max (abs (maxlog x)) (abs (minlog x))) (logspan z) y-slack)
+               (cons (max (+ (maxlog y) (max (abs maxlog-x) (abs minlog-x)) (logspan z) y-slack)
                           y-slack)
                      0)))] ; bounds per y
 

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -159,7 +159,7 @@
 
      ; when output is (ival 0.bf 1.bf) - it means that x was close to 1 or 0 but not narrow enough
      (define x-slack
-       (if (and (bfzero? (ival-lo z)) (bfinteger? (ival-hi z)))
+       (if (bfzero? (ival-lo z))
            (get-slack)
            0))
 

--- a/infra/run-baseline.rkt
+++ b/infra/run-baseline.rkt
@@ -76,7 +76,7 @@
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
       [done? fvec]
       [stuck? (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
-      [(>= (* 2 prec) (*rival-max-precision*)) ; max precision is taken from eval/machine.rkt
+      [(> (* 2 prec) (*rival-max-precision*)) ; max precision is taken from eval/machine.rkt
        (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [else (loop (* 2 prec))])))
 

--- a/main.rkt
+++ b/main.rkt
@@ -99,7 +99,6 @@
          (struct-out exn:rival:invalid)
          (struct-out exn:rival:unsamplable)
          *rival-max-precision*
-         *rival-max-iterations*
          *rival-profile-executions*
          *rival-use-shorthands*
          *rival-name-constants*

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -418,6 +418,8 @@
 ;; Since MPFR has a cap on exponents, no value can be more than twice MAX_VAL
 (define exp-overflow-threshold (bfadd (bflog (bfprev +inf.bf)) 1.bf))
 (define exp2-overflow-threshold (bfadd (bflog2 (bfprev +inf.bf)) 1.bf))
+(define sinh-overflow-threshold (bfadd (bfasinh (bfprev +inf.bf)) 1.bf))
+(define acosh-overflow-threshold (bfadd (bfacosh (bfprev +inf.bf)) 1.bf))
 
 (define (ival-exp x)
   (define y ((monotonic bfexp) x))
@@ -497,8 +499,12 @@
                     (bf=? (ival-lo-val y) 0.bf)
                     (bf=? (ival-hi-val y) 0.bf))))]))
 
-(define* ival-cosh (compose (monotonic bfcosh) ival-exact-fabs))
-(define* ival-sinh (monotonic bfsinh))
+(define*
+ ival-cosh
+ (compose (overflows-at (monotonic bfcosh) (bfneg acosh-overflow-threshold) acosh-overflow-threshold)
+          ival-exact-fabs))
+(define* ival-sinh
+         (overflows-at (monotonic bfsinh) (bfneg sinh-overflow-threshold) sinh-overflow-threshold))
 (define* ival-tanh (monotonic bftanh))
 (define* ival-asinh (monotonic bfasinh))
 (define* ival-acosh (compose (monotonic bfacosh) (clamp 1.bf +inf.bf)))

--- a/time.rkt
+++ b/time.rkt
@@ -185,21 +185,18 @@
 
         ; -------------------------------- Combining results ----------------------------------------
         ; When all the machines have compiled and produced results - write the results to outcomes
-        (when (and (> (*sampling-timeout*) sollya-apply-time)
-                   (> (*sampling-timeout*) rival-apply-time)
-                   (> (*sampling-timeout*) baseline-apply-time))
-          (point-bucketing timeline
-                           rival-status
-                           rival-apply-time
-                           rival-exs
-                           baseline-status
-                           baseline-apply-time
-                           baseline-exs
-                           sollya-status
-                           sollya-apply-time
-                           sollya-exs
-                           baseline-precision
-                           rival-iter))
+        (point-bucketing timeline
+                         rival-status
+                         rival-apply-time
+                         rival-exs
+                         baseline-status
+                         baseline-apply-time
+                         baseline-exs
+                         sollya-status
+                         sollya-apply-time
+                         sollya-exs
+                         baseline-precision
+                         rival-iter)
 
         (when (<= (*sampling-timeout*) sollya-apply-time)
           (*sollya-timeout* (add1 (*sollya-timeout*))))
@@ -549,7 +546,10 @@
        ; These points will go into speed graph
        [(and (equal? 'valid sollya-status)
              (equal? 'valid baseline-status)
-             (equal? rival-status 'valid))
+             (equal? rival-status 'valid)
+             (> (*sampling-timeout*) sollya-time)
+             (> (*sampling-timeout*) rival-time)
+             (> (*sampling-timeout*) baseline-time))
         (timeline-push! timeline
                         'outcomes
                         (list "valid-sollya" rival-iter baseline-precision sollya-time))

--- a/time.rkt
+++ b/time.rkt
@@ -185,18 +185,19 @@
 
         ; -------------------------------- Combining results ----------------------------------------
         ; When all the machines have compiled and produced results - write the results to outcomes
-        (point-bucketing timeline
-                         rival-status
-                         rival-apply-time
-                         rival-exs
-                         baseline-status
-                         baseline-apply-time
-                         baseline-exs
-                         sollya-status
-                         sollya-apply-time
-                         sollya-exs
-                         baseline-precision
-                         rival-iter)
+        (when (> (*sampling-timeout*) sollya-apply-time)
+          (point-bucketing timeline
+                           rival-status
+                           rival-apply-time
+                           rival-exs
+                           baseline-status
+                           baseline-apply-time
+                           baseline-exs
+                           sollya-status
+                           sollya-apply-time
+                           sollya-exs
+                           baseline-precision
+                           rival-iter))
 
         (when (<= (*sampling-timeout*) sollya-apply-time)
           (*sollya-timeout* (add1 (*sollya-timeout*))))

--- a/utils.rkt
+++ b/utils.rkt
@@ -16,9 +16,9 @@
   (discretization n
                   (lambda (x)
                     (parameterize ([bf-precision n])
-                      (bfcopy x)))
+                      (if (equal? (bigfloats-between 0.bf x) 1)
+                          (bf 0)
+                          (bfcopy x))))
                   (lambda (x y)
                     (parameterize ([bf-precision n])
-                      (if (bfzero? x)
-                          (max (- (abs (bigfloats-between x y)) 1) 0)
-                          (abs (bigfloats-between x y)))))))
+                      (abs (bigfloats-between x y))))))

--- a/utils.rkt
+++ b/utils.rkt
@@ -19,4 +19,6 @@
                       (bfcopy x)))
                   (lambda (x y)
                     (parameterize ([bf-precision n])
-                      (abs (bigfloats-between x y))))))
+                      (if (bfzero? x)
+                          (max (- (abs (bigfloats-between x y)) 1) 0)
+                          (abs (bigfloats-between x y)))))))


### PR DESCRIPTION
This PR eliminates an iteration limit for the Rival's evaluation loop.
The reason is: iteration limit may terminate the evaluation early than necessary. 
Especially it matters for evaluation of an expression with numerous uncertainties (4+).
Such expressions may require more than 5 iterations to define a correct rounding. 
The introduced feature makes the evaluation loop more robust.