### PR TITLE
Few optimizations to prevent overflows at some particular benchmarks

### DIFF
--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -125,6 +125,10 @@
     [`(pow ,arg 1/3) `(cbrt ,arg)]
     [`(pow ,arg 1/2) `(sqrt ,arg)]
 
+    ; Some simplifications to prevent overflow
+    [`(log (exp ,x)) x]
+    [`(log (pow ,x ,y)) `(* ,y (log ,x))]
+
     ; Special trigonometric functions
     [`(cos (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
      #:when bfcosu

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -209,10 +209,9 @@
   ; Translates programs into an instruction sequence of operations
   (define (munge prog)
     (define node ; This compiles to the register machine
-      (let ([prog* (optimize prog)])
-        (match prog*
-          [(list op args ...) (cons op (map munge args))]
-          [_ prog*])))
+      (match (optimize prog)
+        [(list op args ...) (cons op (map munge args))]
+        [prog* prog*]))
     (hash-ref! exprhash
                node
                (lambda ()

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -124,6 +124,7 @@
     [`(pow ,arg 2) `(pow2 ,arg)]
     [`(pow ,arg 1/3) `(cbrt ,arg)]
     [`(pow ,arg 1/2) `(sqrt ,arg)]
+    [`(pow 2 ,arg) `(exp2 ,arg)]
 
     ; Special trigonometric functions
     [`(cos (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
@@ -192,7 +193,6 @@
 
     ; Some simplifications to prevent overflow
     [`(log (exp ,x)) x]
-    [`(log (pow ,x ,y)) `(* ,y (log ,x))]
     [_ expr]))
 
 (define (exprs->batch exprs vars)

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -193,6 +193,7 @@
 
     ; Some simplifications to prevent overflow
     [`(log (exp ,x)) x]
+    [`(exp (log ,x)) `(then (assert (> ,x 0)) ,x)]
     [_ expr]))
 
 (define (exprs->batch exprs vars)

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -125,10 +125,6 @@
     [`(pow ,arg 1/3) `(cbrt ,arg)]
     [`(pow ,arg 1/2) `(sqrt ,arg)]
 
-    ; Some simplifications to prevent overflow
-    [`(log (exp ,x)) x]
-    [`(log (pow ,x ,y)) `(* ,y (log ,x))]
-
     ; Special trigonometric functions
     [`(cos (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))
      #:when bfcosu
@@ -193,6 +189,10 @@
        [(and (even? (numerator y)) (odd? (denominator y))) `(pow (fabs ,x) ,y)]
        [(and (odd? (numerator y)) (odd? (denominator y))) `(copysign (pow (fabs ,x) ,y) ,x)]
        [else `(pow ,x ,y)])]
+
+    ; Some simplifications to prevent overflow
+    [`(log (exp ,x)) x]
+    [`(log (pow ,x ,y)) `(* ,y (log ,x))]
     [_ expr]))
 
 (define (exprs->batch exprs vars)

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -418,6 +418,8 @@
 ;; Since MPFR has a cap on exponents, no value can be more than twice MAX_VAL
 (define exp-overflow-threshold (bfadd (bflog (bfprev +inf.bf)) 1.bf))
 (define exp2-overflow-threshold (bfadd (bflog2 (bfprev +inf.bf)) 1.bf))
+(define sinh-overflow-threshold (bfadd (bfasinh (bfprev +inf.bf)) 1.bf))
+(define acosh-overflow-threshold (bfadd (bfacosh (bfprev +inf.bf)) 1.bf))
 
 (define (ival-exp x)
   (define y ((monotonic bfexp) x))
@@ -497,8 +499,12 @@
                     (bf=? (ival-lo-val y) 0.bf)
                     (bf=? (ival-hi-val y) 0.bf))))]))
 
-(define* ival-cosh (compose (monotonic bfcosh) ival-exact-fabs))
-(define* ival-sinh (monotonic bfsinh))
+(define*
+ ival-cosh
+ (compose (overflows-at (monotonic bfcosh) (bfneg acosh-overflow-threshold) acosh-overflow-threshold)
+          ival-exact-fabs))
+(define* ival-sinh
+         (overflows-at (monotonic bfsinh) (bfneg sinh-overflow-threshold) sinh-overflow-threshold))
 (define* ival-tanh (monotonic bftanh))
 (define* ival-asinh (monotonic bfasinh))
 (define* ival-acosh (compose (monotonic bfacosh) (clamp 1.bf +inf.bf)))


### PR DESCRIPTION
Despite that #85 was not merged, it revealed a room for improvement that may save runtime.
This PR adds two optimizations to the `rival-compile` functionality that will allow us to overflow less.