### PR TITLE
Adding boolean discretization for repl

### DIFF
--- a/repl.rkt
+++ b/repl.rkt
@@ -23,10 +23,9 @@
            (define tru-type (loop tru))
            (define fls-type (loop fls))
            (when (not (equal? tru-type fls-type))
-             (error "Types of the false and true branches should match"))
+             (raise-user-error 'create-discs "Types of the false and true branches should match"))
            tru-type]
-          [(list 'then x y)
-           (loop y)]
+          [(list 'then x y) (loop y)]
           [_ 'bf])))
     (match body-type
       ['bool boolean-discretization]
@@ -95,9 +94,7 @@
 (define (repl-save-machine! repl name args bodies)
   (hash-set! (repl-context repl)
              name
-             (rival-compile (map fix-up-fpcore bodies)
-                            args
-                            (create-discs bodies repl))))
+             (rival-compile (map fix-up-fpcore bodies) args (create-discs bodies repl))))
 
 (define (check-args! name machine vals)
   (unless (= (vector-length (rival-machine-arguments machine)) (length vals))


### PR DESCRIPTION
This PR introduces a little typecheck for Rival's repl.
The bug was discovered by @bksaiki when trying a simple example in Rival's repl:
```
> (define (f) (> (+ (/ 2 5) (/ 1 5)) (/ 3 5)))
> (eval f)
mpfr->C: argument is not non-null `mpfr' pointer
  argument: #f
  context...:
   /opt/racket/8.14/share/pkgs/math-lib/math/private/bigfloat/mpfr.rkt:900:0: bigfloat->ordinal
   /opt/racket/8.14/share/pkgs/math-lib/math/private/bigfloat/mpfr.rkt:925:0: bigfloats-between
   /opt/racket/8.14/share/pkgs/typed-racket-lib/typed-racket/utils/simple-result-arrow.rkt:39:12
   /home/bsaiki/.local/share/racket/8.14/pkgs/rival/utils.rkt:17:18
   /home/bsaiki/.local/share/racket/8.14/pkgs/rival/eval/run.rkt:68:0: rival-machine-return
   /home/bsaiki/.local/share/racket/8.14/pkgs/rival/eval/main.rkt:65:0: rival-apply
   /home/bsaiki/.local/share/racket/8.14/pkgs/rival/repl.rkt:151:2
   body of (submod "/home/bsaiki/.local/share/racket/8.14/pkgs/rival/main.rkt" main)
```
The reason for this bug is using `bf-discretization` for every program the gets inputted into Rival's repl.
However, the example is clearly a boolean type.
Despite that the example can be fixed with boolean type, Rival fails to evaluate and marks the evaluation as `unsamplable`, there is probably nothing can be done about it since the left-hand side is mathematically equal to right-hand side.

The PR introduces a little typechecking that allows to match a discretization with an expression return type.