### PR TITLE
Distribution for Rival's REPL

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -1,6 +1,9 @@
 name: Distribute
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   distribute:

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -1,0 +1,49 @@
+name: Distribute
+
+on: [push]
+
+jobs:
+  distribute:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            arch: aarch64
+          - os: macos-13
+            arch: x64
+          - os: ubuntu-latest
+            arch: x64
+          - os: windows-latest
+            arch: x64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: "Install Racket"
+        uses: Bogdanp/setup-racket@v1.11
+        with:
+            version: "8.14"
+            architecture: ${{ matrix.arch }}
+      # WARN: need to be careful with cargo paths
+      - name: Cache Racket dependencies
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-deps
+          path: |
+            ~/.cache/racket
+            ~/.local/share/racket
+            ~/Library/Racket/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ${{ env.APPDATA }}/Racket
+      # Build executable and remove Herbie launcher
+      - name: "Build standalone executable"
+        run: make distribution
+      # Test executable
+      - name: "Test executable, run repl (Windows)"
+        if: runner.os == 'Windows'
+        run: rival-compiled/rival.exe
+      - name: "Test executable, run repl (Linux / MacOS)"
+        if: runner.os != 'Windows'
+        run: rival-compiled/bin/rival

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -27,19 +27,6 @@ jobs:
         with:
             version: "8.14"
             architecture: ${{ matrix.arch }}
-      # WARN: need to be careful with cargo paths
-      - name: Cache Racket dependencies
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-deps
-          path: |
-            ~/.cache/racket
-            ~/.local/share/racket
-            ~/Library/Racket/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ${{ env.APPDATA }}/Racket
       - uses: actions/checkout@master
       - name: "Build standalone executable"
         run: make distribution

--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ${{ env.APPDATA }}/Racket
-      # Build executable and remove Herbie launcher
+      - uses: actions/checkout@master
       - name: "Build standalone executable"
         run: make distribution
       # Test executable

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out.html
 profile.json
 *.*~
 report/*
+rival-compiled

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ distribution:
 	mkdir -p rival-compiled/
 	cp README.md rival-compiled/
 	cp LICENSE rival-compiled/
+	raco make main.rkt
 	raco exe -o rival --orig-exe --embed-dlls --vv main.rkt
 	[ ! -f rival.exe ] || (raco distribute rival-compiled rival.exe && rm rival.exe)
 	[ ! -f rival.app ] || (raco distribute rival-compiled rival.app && rm rival.app)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
 .PHONY: nightly hook
 
-
-
 nightly:
 	bash infra/nightly.sh perf
 	nightly-results publish report/
 
 fmt:
 	@raco fmt -i $(shell find infra/ ops/ eval/ ./ -name '*.rkt')
+
+distribute:
+	mkdir -p rival-compiled/
+	cp README.md rival-compiled/
+	cp LICENSE rival-compiled/
+	raco exe -o rival --orig-exe --embed-dlls --vv main.rkt
+	[ ! -f rival.exe ] || (raco distribute rival-compiled rival.exe && rm rival.exe)
+	[ ! -f rival.app ] || (raco distribute rival-compiled rival.app && rm rival.app)
+	[ ! -f rival ] || (raco distribute rival-compiled rival && rm rival)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ nightly:
 fmt:
 	@raco fmt -i $(shell find infra/ ops/ eval/ ./ -name '*.rkt')
 
-distribute:
+distribution:
 	mkdir -p rival-compiled/
 	cp README.md rival-compiled/
 	cp LICENSE rival-compiled/


### PR DESCRIPTION
This pull request updates a set of rules of `Makefile` by adding a `distribution` rule which compiles an executable for Rival's REPL (read–evaluate–print loop).

