### PR TITLE
Analyze hint usage

### DIFF
--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -113,7 +113,6 @@
             (for-each (λ (x) (vhint-set! x #t)) srcs)
             (set! converged? #f)
             #t])]
-
         [else ; at this point we are given that the current instruction should be executed
          (define srcs (rest instr)) ; then, children instructions should be executed as well
          (for-each (λ (x) (vhint-set! x #t)) srcs)

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -29,7 +29,7 @@
                    incremental-precisions
                    output-distance
                    initial-precision
-                   hint
+                   default-hint
                    [iteration #:mutable]
                    [bumps #:mutable]
                    [profile-ptr #:mutable]

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -24,7 +24,7 @@
 
 (define ground-truth-require-convergence (make-parameter #t))
 
-(define (rival-machine-full machine inputs [vhint (rival-machine-hint machine)])
+(define (rival-machine-full machine inputs vhint)
   (set-rival-machine-iteration! machine (*sampling-iteration*))
   (rival-machine-adjust machine vhint)
   (cond
@@ -71,7 +71,7 @@
                      [ground-truth-require-convergence #t])
         (rival-machine-full machine
                             (vector-map ival-real pt)
-                            (or hint (rival-machine-hint machine)))))
+                            (or hint (rival-machine-default-hint machine)))))
     (cond
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
       [done? fvec]
@@ -84,6 +84,6 @@
   (define-values (good? done? bad? stuck? fvec)
     (parameterize ([*sampling-iteration* 0]
                    [ground-truth-require-convergence #f])
-      (rival-machine-full machine rect (or hint (rival-machine-hint machine)))))
+      (rival-machine-full machine rect (or hint (rival-machine-default-hint machine)))))
   (define-values (hint* hint*-converged?) (make-hint machine))
   (list (ival (or bad? stuck?) (not good?)) hint* hint*-converged?))

--- a/eval/tests.rkt
+++ b/eval/tests.rkt
@@ -90,7 +90,6 @@
   ; Testing hint on an expression for 'number-of-random-hyperrects' hyperrects by
   ;     'number-of-random-pts-per-rect' points each
   (define (hints-random-checks machine rect-lo rect-hi varc)
-    (define evaluated-instructions 0)
     (define number-of-instructions-total
       (* number-of-random-hyperrects (vector-length (rival-machine-instructions machine))))
 
@@ -98,8 +97,14 @@
     (define no-hint-cnt 0)
     (for ([n (in-range number-of-random-hyperrects)])
       (define hyperrect (sample-hyperrect-within-bounds rect-lo rect-hi varc))
-      (match-define (list res hint _) (rival-analyze machine hyperrect))
-      (set! evaluated-instructions (+ evaluated-instructions (vector-count false? hint)))
+      (match-define (list res hint converged?) (rival-analyze machine hyperrect))
+
+      ; A little hack, the analyze below uses hint from the previous run
+      ; The analyze results must be equal. If not, something wrong has happened
+      (match-define (list res* hint* converged?*) (rival-analyze machine hyperrect hint))
+      (check-equal? hint hint*)
+      (check-equal? res res*)
+      (check equal? converged? converged?*)
 
       (for ([_ (in-range number-of-random-pts-per-rect)])
         (define pt (sample-pts hyperrect))

--- a/main.rkt
+++ b/main.rkt
@@ -90,13 +90,14 @@
 
 (require "eval/main.rkt"
          (only-in "eval/machine.rkt" rival-machine?))
-(provide (contract-out [rival-compile
-                        (-> (listof any/c) (listof symbol?) (listof discretization?) rival-machine?)]
-                       [rival-apply
-                        (->* (rival-machine? (vectorof value?))
-                             ((or/c (vectorof any/c) boolean?))
-                             (vectorof any/c))]
-                       [rival-analyze (-> rival-machine? (vectorof ival?) (listof any/c))])
+(provide (contract-out
+          [rival-compile (-> (listof any/c) (listof symbol?) (listof discretization?) rival-machine?)]
+          [rival-apply
+           (->* (rival-machine? (vectorof value?))
+                ((or/c (vectorof any/c) boolean?))
+                (vectorof any/c))]
+          [rival-analyze
+           (->* (rival-machine? (vectorof ival?)) ((or/c (vectorof any/c) boolean?)) (listof any/c))])
          (struct-out discretization)
          (struct-out exn:rival)
          (struct-out exn:rival:invalid)


### PR DESCRIPTION
This PR continues #87 story.
I didn't realize at that time, but `rival-analyze` also can use hints to reduce computational path.
It can be used in Herbie at analyze stage when we split hyperrects.
The thing is that a hint from hyperrect `[a, b]` can be used at `[a, a+b/2]` and `[a+b/2, b]` hyperrects when applying `rival-analyze`.
At the current time we are just dropping this hint, but it can be reused further and some time can be saved.