### PR TITLE
New hint propogation using old hint as a guide

### DIFF
--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -62,6 +62,7 @@
 (define (ival-real x)
   (ival x))
 
+; Assumes that hint (if provided) is correct for the given pt
 (define (rival-apply machine pt [hint #f])
   (define discs (rival-machine-discs machine))
   (set-rival-machine-bumps! machine 0)
@@ -80,10 +81,12 @@
        (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [else (loop (+ 1 iter))])))
 
+; Assumes that hint (if provided) is correct for the given rect
 (define (rival-analyze machine rect [hint #f])
   (define-values (good? done? bad? stuck? fvec)
     (parameterize ([*sampling-iteration* 0]
                    [ground-truth-require-convergence #f])
       (rival-machine-full machine rect (or hint (rival-machine-default-hint machine)))))
-  (define-values (hint* hint*-converged?) (make-hint machine))
+  (define-values (hint* hint*-converged?)
+    (make-hint machine (or hint (rival-machine-default-hint machine))))
   (list (ival (or bad? stuck?) (not good?)) hint* hint*-converged?))


### PR DESCRIPTION
This PR fixes an issue that has been observed with `make-hint` function.
It has been observed that `make-hint` was not deterministic and could produce different results for the same hyperrects with and without a _hint_.
An issue have been found.

In the current implementation, a _hint_ for instruction `(list ival-fmax arg1 arg2)` was calculated as:
take `arg1` register and `arg2` register, compare them and then decide which path to choose.
But there is an issue with that:
Imagine that we are using a _hint_ that have marked `fmax` as `1` - which means "execute only `arg1`".
Therefore, `arg2` just was not executed at all, `arg2` register stores some nonsense from previous runs.
When making new _hint_, we still access this memory and compare nonsense with valid interval.
Thus, the results of `make-hint` relied on some nonsense.

That was fixed, and now an additional argument `old-hint` is added to `make-hint` function to take this case into account.
The logic got slightly more complicated:
If we are given any instruction we, firstly, check whether `old-hint` has already defined the right path for the instruction.
If so, just copy the right path to the next child.
If not, take `arg1` register and `arg2` register, compare them and then decide which path to choose.
