### PR TITLE
Fix of function that assigns `base-tuning` precisions

### DIFF
--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -314,10 +314,9 @@
                  (- root varc)
                  (+ (discretization-target disc) (*base-tuning-precision*))))
 
-  (for ([instr (in-vector ivec (- ivec-len 1) -1 -1)] ; reversed over ivec
-        [n (in-range (- ivec-len 1) -1 -1)]) ; reversed over indices of vstart-precs
+  (for ([n (in-range (- ivec-len 1) -1 -1)]) ; reversed over ivec
+    (define instr (vector-ref ivec n))
     (define current-prec (vector-ref vstart-precs n))
-
     (define tail-registers (cdr instr))
     (for ([idx (in-list tail-registers)]
           #:when (>= idx varc))


### PR DESCRIPTION
An interesting bug was discovered by @bksaiki!

```
$ racket -l rival
> (define (f x) x)
in-vector: contract violation
  expected: exact-nonnegative-integer?
  given: -1
  context...:
   /opt/racket/8.14/collects/racket/private/for.rkt:973:2: check-ranges
   /opt/racket/8.14/collects/racket/private/for.rkt:1002:2: normalise-inputs
   /home/bsaiki/research/herbie-fp/rival/eval/compile.rkt:308:0: setup-vstart-precs
   /home/bsaiki/research/herbie-fp/rival/eval/compile.rkt:267:0: rival-compile
   /home/bsaiki/research/herbie-fp/rival/repl.rkt:107:0: repl-save-machine!
   /home/bsaiki/research/herbie-fp/rival/repl.rkt:247:2
   body of (submod "/home/bsaiki/research/herbie-fp/rival/main.rkt" main
   ```
   For some reasons, Rival didn't want to compile a simple expression.
   The bug was found, the reason behind is that `setup-vstart-precs` iterates over a vector and a range of numbers.
   It looks like:
```
(define ivec (vector))
(define ivec-len 0)
(for ([n (in-range (- ivec-len 1) -1 -1)]
      [instr (in-vector ivec (- ivec-len 1) -1 -1)])
      ...
```
Interesting things start to happen when the length of the vector is zero.
It crashes because of _illegal_ range for iterating over vector (not a problem for `in-range` though).
The second line just needs to be accessed manually.