### PR TITLE
Baseline updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ profile.json
 *.*~
 report/*
 rival-compiled
+Makefile~

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -22,8 +22,6 @@
          (struct-out execution)
          *rival-profile-executions*)
 
-(define ground-truth-require-convergence (make-parameter #t))
-
 (define (rival-machine-full machine vhint)
   (set-rival-machine-iteration! machine (*sampling-iteration*))
   (rival-machine-adjust machine vhint)
@@ -69,8 +67,7 @@
   (rival-machine-load machine (vector-map ival-real pt))
   (let loop ([iter 0])
     (define-values (good? done? bad? stuck? fvec)
-      (parameterize ([*sampling-iteration* iter]
-                     [ground-truth-require-convergence #t])
+      (parameterize ([*sampling-iteration* iter])
         (rival-machine-full machine (or hint (rival-machine-default-hint machine)))))
     (cond
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
@@ -82,10 +79,10 @@
 
 ; Assumes that hint (if provided) is correct for the given rect
 (define (rival-analyze machine rect [hint #f])
+  (rival-machine-load machine rect)
   (define-values (good? done? bad? stuck? fvec)
-    (parameterize ([*sampling-iteration* 0]
-                   [ground-truth-require-convergence #f])
-      (rival-machine-full machine rect (or hint (rival-machine-default-hint machine)))))
+    (parameterize ([*sampling-iteration* 0])
+      (rival-machine-full machine (or hint (rival-machine-default-hint machine)))))
   (define-values (hint* hint*-converged?)
     (make-hint machine (or hint (rival-machine-default-hint machine))))
   (list (ival (or bad? stuck?) (not good?)) hint* hint*-converged?))

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -61,10 +61,9 @@
 
 ; Assumes that hint (if provided) is correct for the given pt
 (define (rival-apply machine pt [hint #f])
-  (define discs (rival-machine-discs machine))
-  (set-rival-machine-bumps! machine 0)
   ; Load arguments
   (rival-machine-load machine (vector-map ival-real pt))
+  (set-rival-machine-bumps! machine 0)
   (let loop ([iter 0])
     (define-values (good? done? bad? stuck? fvec)
       (parameterize ([*sampling-iteration* iter])
@@ -79,6 +78,7 @@
 
 ; Assumes that hint (if provided) is correct for the given rect
 (define (rival-analyze machine rect [hint #f])
+  ; Load arguments
   (rival-machine-load machine rect)
   (define-values (good? done? bad? stuck? fvec)
     (parameterize ([*sampling-iteration* 0])

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -24,13 +24,12 @@
 
 (define ground-truth-require-convergence (make-parameter #t))
 
-(define (rival-machine-full machine inputs vhint)
+(define (rival-machine-full machine vhint)
   (set-rival-machine-iteration! machine (*sampling-iteration*))
   (rival-machine-adjust machine vhint)
   (cond
     [(>= (*sampling-iteration*) (*rival-max-iterations*)) (values #f #f #f #t #f)]
     [else
-     (rival-machine-load machine inputs)
      (rival-machine-run machine vhint)
      (rival-machine-return machine)]))
 
@@ -66,13 +65,13 @@
 (define (rival-apply machine pt [hint #f])
   (define discs (rival-machine-discs machine))
   (set-rival-machine-bumps! machine 0)
+  ; Load arguments
+  (rival-machine-load machine (vector-map ival-real pt))
   (let loop ([iter 0])
     (define-values (good? done? bad? stuck? fvec)
       (parameterize ([*sampling-iteration* iter]
                      [ground-truth-require-convergence #t])
-        (rival-machine-full machine
-                            (vector-map ival-real pt)
-                            (or hint (rival-machine-default-hint machine)))))
+        (rival-machine-full machine (or hint (rival-machine-default-hint machine)))))
     (cond
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
       [done? fvec]

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -63,7 +63,6 @@
 (define (rival-apply machine pt [hint #f])
   ; Load arguments
   (rival-machine-load machine (vector-map ival-real pt))
-  (set-rival-machine-bumps! machine 0)
   (let loop ([iter 0])
     (define-values (good? done? bad? stuck? fvec)
       (parameterize ([*sampling-iteration* iter])

--- a/eval/run.rkt
+++ b/eval/run.rkt
@@ -16,7 +16,7 @@
 
 (define (rival-machine-load machine args)
   (vector-copy! (rival-machine-registers machine) 0 args)
-  #;(set-rival-machine-iteration! machine 0))
+  (set-rival-machine-bumps! machine 0))
 
 (define (rival-machine-record machine name number precision time)
   (define profile-ptr (rival-machine-profile-ptr machine))

--- a/infra/histograms.py
+++ b/infra/histograms.py
@@ -16,11 +16,14 @@ def plot_histogram_valid(args):
     baseline = load_mixsample(args.timeline, "baseline", True)
     rival = load_mixsample(args.timeline, "rival", True)
 
-    adjust_time = round(rival[rival["op"] == 'adjust']['time'].sum()/1000, 2)
+    adjust_time_baseline = round(baseline[baseline["op"] == 'adjust']['time'].sum()/1000, 2)
+    baseline = baseline[baseline["op"] != 'adjust']
+
+    adjust_time_rival = round(rival[rival["op"] == 'adjust']['time'].sum()/1000, 2)
     rival = rival[rival["op"] != 'adjust']
 
-    print("\\newcommand{\\TuningTime}{" + str(adjust_time) + "\\xspace}")
-    print("\\newcommand{\\TuningTimePercentage}{" + str(round(adjust_time/rival['time'].sum()*1000 * 100, 1)) + "}")
+    print("\\newcommand{\\TuningTime}{" + str(adjust_time_rival) + "\\xspace}")
+    print("\\newcommand{\\TuningTimePercentage}{" + str(round(adjust_time_rival/rival['time'].sum()*1000 * 100, 1)) + "}")
     print("\\newcommand{\\RivalSpeedupHistograms}{" + str(round((baseline['time'].sum()-rival['time'].sum())/baseline['time'].sum() * 100, 2)) + "}")
 
     fig, ax = plt.subplots(figsize=(6.5, 2.75))
@@ -33,9 +36,16 @@ def plot_histogram_valid(args):
     ax.bar(np.arange(len(bins)) + 0.4, buckets_base, color="green", alpha=1, width=0.6, label='baseline', hatch='/')
     ax.bar(np.arange(len(bins)) + 0.6, buckets_rival, color="red", alpha=0.7, width=0.6, label='reval')
 
-    temp = np.zeros_like(buckets_rival)
-    temp[-1] = adjust_time
-    ax.bar(np.arange(len(bins)), temp, color="red", alpha=0.7, width=0.6)
+    # Baseline tuning time
+    tuning_time_baseline = np.zeros_like(buckets_base)
+    tuning_time_baseline[-1] = adjust_time_baseline
+    ax.bar(np.arange(len(bins)) - 0.1, tuning_time_baseline, color="green", alpha=1, width=0.6, hatch='/')
+
+    # Reval tuning time
+    tuning_time_rival = np.zeros_like(buckets_rival)
+    tuning_time_rival[-1] = adjust_time_rival
+    ax.bar(np.arange(len(bins)) + 0.1, tuning_time_rival, color="red", alpha=0.7, width=0.6)
+
     ax.yaxis.grid(True, linestyle='-', which='major', color='grey', alpha=0.3)
 
     ax.set_xticks(np.arange(len(bins)), bins)
@@ -57,7 +67,10 @@ def plot_histogram_all(args):
     baseline = load_mixsample(args.timeline, "baseline", False)
     rival = load_mixsample(args.timeline, "rival", False)
 
-    adjust_time = round(rival[rival["op"] == 'adjust']['time'].sum()/1000, 2)
+    adjust_time_baseline = round(baseline[baseline["op"] == 'adjust']['time'].sum()/1000, 2)
+    baseline = baseline[baseline["op"] != 'adjust']
+
+    adjust_time_rival = round(rival[rival["op"] == 'adjust']['time'].sum()/1000, 2)
     rival = rival[rival["op"] != 'adjust']
 
     fig, ax = plt.subplots(figsize=(6.5, 2.0))
@@ -70,9 +83,16 @@ def plot_histogram_all(args):
     ax.bar(np.arange(len(bins)) + 0.4, buckets_base, color="green", alpha=1, width=0.6, label='baseline', hatch='/')
     ax.bar(np.arange(len(bins)) + 0.6, buckets_rival, color="red", alpha=0.7, width=0.6, label='reval')
 
-    temp = np.zeros_like(buckets_rival)
-    temp[-1] = adjust_time
-    ax.bar(np.arange(len(bins)), temp, color="red", alpha=0.7, width=0.6)
+    # Baseline tuning time
+    tuning_time_baseline = np.zeros_like(buckets_base)
+    tuning_time_baseline[-1] = adjust_time_baseline
+    ax.bar(np.arange(len(bins)) - 0.1, tuning_time_baseline, color="green", alpha=1, width=0.6, hatch='/')
+ 
+    # Reval tuning time
+    tuning_time_rival = np.zeros_like(buckets_rival)
+    tuning_time_rival[-1] = adjust_time_rival
+    ax.bar(np.arange(len(bins)) + 0.1, tuning_time_rival, color="red", alpha=0.7, width=0.6)
+
     ax.yaxis.grid(True, linestyle='-', which='major', color='grey', alpha=0.3)
 
     ax.set_xticks(np.arange(len(bins)), bins)

--- a/infra/repeats_plot.py
+++ b/infra/repeats_plot.py
@@ -16,15 +16,18 @@ def plot_repeats_plot(outcomes, args):
     rival = (outcomes.loc[(outcomes['tool'] == "rival") & (outcomes['iter'] > 0)]).sort_values(by=['iter'])
     rival_no_repeats = (outcomes.loc[(outcomes['tool'] == "rival-no-repeats") & (outcomes['iter'] > 0)]).sort_values(by=['iter'])
     baseline = (outcomes.loc[(outcomes['tool'] == "baseline") & (outcomes['iter'] > 0)]).sort_values(by=['iter'])
+    baseline_no_repeats = (outcomes.loc[(outcomes['tool'] == "baseline-no-repeats") & (outcomes['iter'] > 0)]).sort_values(by=['iter'])
     
     average = round((1.0 - (rival['number_of_instr_executions'].sum() / rival_no_repeats['number_of_instr_executions'].sum())) * 100, 2)
     print("\\newcommand{\\AveragePercentageOfSkippedInstr}{" + str(average) + "}")
     maximum = round((1.0 - (np.array(rival['number_of_instr_executions'])[-1] / np.array(rival_no_repeats['number_of_instr_executions'])[-1])) * 100, 2)
     print("\\newcommand{\\MaximumPercentageOfSkippedInstr}{" + str(maximum) + "}")
 
-    # ax.bar(np.arange(len(baseline)) + 0.925, 100, color="green", alpha=1, width=0.5, label='baseline', hatch='/')
+    baseline_percentages = np.array(baseline['number_of_instr_executions']) / np.array(baseline_no_repeats['number_of_instr_executions']) * 100
+    ax.bar(np.arange(len(baseline)) + 0.9, baseline_percentages, color="green", alpha=1, width=0.5, label='baseline', hatch='/')
+
     percentages = np.array(rival['number_of_instr_executions']) / np.array(rival_no_repeats['number_of_instr_executions']) * 100
-    ax.bar(np.arange(len(rival))+1, percentages, color="red", alpha=0.7, width=0.5, label='reval')
+    ax.bar(np.arange(len(rival))+1.1, percentages, color="red", alpha=0.7, width=0.5, label='reval')
     
     # Print percentages
     # for bar in ax.patches:

--- a/infra/run-baseline.rkt
+++ b/infra/run-baseline.rkt
@@ -325,6 +325,7 @@
 ; ---------------------------------------- PROFILING -------------------------------------------------
 (define (baseline-profile machine param)
   (match param
+    ['iteration (baseline-machine-iteration machine)]
     ['precision (baseline-machine-precision machine)]
     ['instructions (vector-length (baseline-machine-instructions machine))]
     ['executions

--- a/infra/run-baseline.rkt
+++ b/infra/run-baseline.rkt
@@ -33,6 +33,116 @@
                    profile-time
                    profile-precision))
 
+(define (make-hint machine old-hint)
+  (define args (baseline-machine-arguments machine))
+  (define ivec (baseline-machine-instructions machine))
+  (define rootvec (baseline-machine-outputs machine))
+  (define vregs (baseline-machine-registers machine))
+
+  (define varc (vector-length args))
+  (define vhint (make-vector (vector-length ivec) #f))
+  (define converged? #t)
+
+  ; helper function
+  (define (vhint-set! idx val)
+    (when (>= idx varc)
+      (vector-set! vhint (- idx varc) val)))
+
+  ; roots always should be executed
+  (for ([root-reg (in-vector rootvec)])
+    (vhint-set! root-reg #t))
+  (for ([instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)]
+        [hint (in-vector vhint (- (vector-length vhint) 1) -1 -1)]
+        [o-hint (in-vector old-hint (- (vector-length old-hint) 1) -1 -1)]
+        [n (in-range (- (vector-length vhint) 1) -1 -1)]
+        #:when hint)
+    (define hint*
+      (match o-hint
+        [(? ival? _) o-hint] ; instr is already "hinted" by old hint, no children are to be recomputed
+        [(? integer? ref) ; instr is already "hinted" by old hint,
+         (define idx (list-ref instr ref)) ; however, one child needs to be recomputed
+         (when (>= idx varc)
+           (vhint-set! idx #t))
+         o-hint]
+        [#t
+         (case (object-name (car instr))
+           [(ival-assert)
+            (match-define (list _ bool-idx) instr)
+            (define bool-reg (vector-ref vregs bool-idx))
+            (match* ((ival-lo bool-reg) (ival-hi bool-reg) (ival-err? bool-reg))
+              ; assert and its children should not be reexecuted if it is true already
+              [(#t #t #f) (ival-bool #t)]
+              ; assert and its children should not be reexecuted if it is false already
+              [(#f #f #f) (ival-bool #f)]
+              [(_ _ _) ; assert and its children should be reexecuted
+               (vhint-set! bool-idx #t)
+               (set! converged? #f)
+               #t])]
+           [(ival-if)
+            (match-define (list _ cond tru fls) instr)
+            (define cond-reg (vector-ref vregs cond))
+            (match* ((ival-lo cond-reg) (ival-hi cond-reg) (ival-err? cond-reg))
+              [(#t #t #f) ; only true path should be executed
+               (vhint-set! tru #t)
+               2]
+              [(#f #f #f) ; only false path should be executed
+               (vhint-set! fls #t)
+               3]
+              [(_ _ _) ; execute both paths and cond as well
+               (vhint-set! cond #t)
+               (vhint-set! tru #t)
+               (vhint-set! fls #t)
+               (set! converged? #f)
+               #t])]
+           [(ival-fmax)
+            (match-define (list _ arg1 arg2) instr)
+            (define cmp (ival-> (vector-ref vregs arg1) (vector-ref vregs arg2)))
+            (match* ((ival-lo cmp) (ival-hi cmp) (ival-err? cmp))
+              [(#t #t #f) ; only arg1 should be executed
+               (vhint-set! arg1 #t)
+               1]
+              [(#f #f #f) ; only arg2 should be executed
+               (vhint-set! arg2 #t)
+               2]
+              [(_ _ _) ; both paths should be executed
+               (vhint-set! arg1 #t)
+               (vhint-set! arg2 #t)
+               (set! converged? #f)
+               #t])]
+           [(ival-fmin)
+            (match-define (list _ arg1 arg2) instr)
+            (define cmp (ival-> (vector-ref vregs arg1) (vector-ref vregs arg2)))
+            (match* ((ival-lo cmp) (ival-hi cmp) (ival-err? cmp))
+              [(#t #t #f) ; only arg2 should be executed
+               (vhint-set! arg2 #t)
+               2]
+              [(#f #f #f) ; only arg1 should be executed
+               (vhint-set! arg1 #t)
+               1]
+              [(_ _ _) ; both paths should be executed
+               (vhint-set! arg1 #t)
+               (vhint-set! arg2 #t)
+               (set! converged? #f)
+               #t])]
+           [(ival-< ival-<= ival-> ival->= ival-== ival-!= ival-and ival-or ival-not)
+            (define cmp (vector-ref vregs (+ varc n)))
+            (match* ((ival-lo cmp) (ival-hi cmp) (ival-err? cmp))
+              ; result is known
+              [(#t #t #f) (ival-bool #t)]
+              ; result is known
+              [(#f #f #f) (ival-bool #f)]
+              [(_ _ _) ; all the paths should be executed
+               (define srcs (rest instr))
+               (for-each (λ (x) (vhint-set! x #t)) srcs)
+               (set! converged? #f)
+               #t])]
+           [else ; at this point we are given that the current instruction should be executed
+            (define srcs (rest instr)) ; then, children instructions should be executed as well
+            (for-each (λ (x) (vhint-set! x #t)) srcs)
+            #t])]))
+    (vector-set! vhint n hint*))
+  (values vhint converged?))
+
 ; ----------------------------------------- COMPILATION ----------------------------------------------
 (define (baseline-compile exprs vars discs)
   (define num-vars (length vars))
@@ -91,36 +201,51 @@
        (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [else (loop (* 2 prec) (+ iter 1))])))
 
+(define (baseline-analyze machine rect [hint #f])
+  (baseline-machine-load machine rect)
+  (set-baseline-machine-iteration! machine 0)
+  (define-values (good? done? bad? stuck? fvec)
+    (baseline-machine-full machine (or hint (baseline-machine-default-hint machine))))
+  (define-values (hint* hint*-converged?)
+    (make-hint machine (or hint (baseline-machine-default-hint machine))))
+  (list (ival (or bad? stuck?) (not good?)) hint* hint*-converged?))
+
 (define (baseline-machine-adjust machine)
-  (set-baseline-machine-precision! machine (bf-precision))
-  (vector-fill! (baseline-machine-precisions machine) (bf-precision))
+  (let ([start (current-inexact-milliseconds)])
+    (set-baseline-machine-precision! machine (bf-precision))
+    (vector-fill! (baseline-machine-precisions machine) (bf-precision))
 
-  ; Whether a register is fixed already
-  (define iter (baseline-machine-iteration machine))
-  (unless (zero? iter)
-    (define ivec (baseline-machine-instructions machine))
-    (define vregs (baseline-machine-registers machine))
-    (define rootvec (baseline-machine-outputs machine))
-    (define repeats (baseline-machine-repeats machine))
-    (define args (baseline-machine-arguments machine))
-    (define varc (vector-length args))
+    ; Whether a register is fixed already
+    (define iter (baseline-machine-iteration machine))
+    (unless (zero? iter)
+      (define ivec (baseline-machine-instructions machine))
+      (define vregs (baseline-machine-registers machine))
+      (define rootvec (baseline-machine-outputs machine))
+      (define repeats (baseline-machine-repeats machine))
+      (define args (baseline-machine-arguments machine))
+      (define varc (vector-length args))
 
-    (define vuseful (make-vector (vector-length ivec) #f))
+      (define vuseful (make-vector (vector-length ivec) #f))
 
-    (for ([root (in-vector rootvec)]
-          #:when (>= root varc))
-      (vector-set! vuseful (- root varc) #t))
-    (for ([reg (in-vector vregs (- (vector-length vregs) 1) (- varc 1) -1)]
-          [instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)]
-          [i (in-range (- (vector-length ivec) 1) -1 -1)]
-          [useful? (in-vector vuseful (- (vector-length vuseful) 1) -1 -1)])
-      (cond
-        [(and (ival-lo-fixed? reg) (ival-hi-fixed? reg)) (vector-set! vuseful i #f)]
-        [useful?
-         (for ([arg (in-list (cdr instr))]
-               #:when (>= arg varc))
-           (vector-set! vuseful (- arg varc) #t))]))
-    (vector-copy! repeats 0 (vector-map not vuseful))))
+      (for ([root (in-vector rootvec)]
+            #:when (>= root varc))
+        (vector-set! vuseful (- root varc) #t))
+      (for ([reg (in-vector vregs (- (vector-length vregs) 1) (- varc 1) -1)]
+            [instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)]
+            [i (in-range (- (vector-length ivec) 1) -1 -1)]
+            [useful? (in-vector vuseful (- (vector-length vuseful) 1) -1 -1)])
+        (cond
+          [(and (ival-lo-fixed? reg) (ival-hi-fixed? reg)) (vector-set! vuseful i #f)]
+          [useful?
+           (for ([arg (in-list (cdr instr))]
+                 #:when (>= arg varc))
+             (vector-set! vuseful (- arg varc) #t))]))
+      (vector-copy! repeats 0 (vector-map not vuseful)))
+    (baseline-machine-record machine
+                             'adjust
+                             -1
+                             (* iter 1000)
+                             (- (current-inexact-milliseconds) start))))
 
 (define (baseline-machine-full machine vhint)
   (baseline-machine-adjust machine)

--- a/main.rkt
+++ b/main.rkt
@@ -107,6 +107,7 @@
                 ((or/c (vectorof any/c) boolean?))
                 (vectorof any/c))]
           [baseline-profile (-> baseline-machine? symbol? any/c)])
+         (struct-out baseline-machine)
          (struct-out discretization)
          (struct-out exn:rival)
          (struct-out exn:rival:invalid)
@@ -116,8 +117,7 @@
          *rival-profile-executions*
          *rival-use-shorthands*
          *rival-name-constants*
-         (struct-out execution)
-         (contract-out))
+         (struct-out execution))
 
 (require "utils.rkt")
 (provide flonum-discretization

--- a/main.rkt
+++ b/main.rkt
@@ -4,7 +4,8 @@
          racket/contract)
 (define value? (or/c bigfloat? boolean?))
 
-(require "ops/all.rkt")
+(require "ops/all.rkt"
+         "infra/run-baseline.rkt")
 (define ival-list? (listof ival?))
 
 (provide ival?
@@ -97,7 +98,15 @@
                 ((or/c (vectorof any/c) boolean?))
                 (vectorof any/c))]
           [rival-analyze
-           (->* (rival-machine? (vectorof ival?)) ((or/c (vectorof any/c) boolean?)) (listof any/c))])
+           (->* (rival-machine? (vectorof ival?)) ((or/c (vectorof any/c) boolean?)) (listof any/c))]
+          [rival-profile (-> rival-machine? symbol? any/c)]
+          [baseline-compile
+           (-> (listof any/c) (listof symbol?) (listof discretization?) baseline-machine?)]
+          [baseline-apply
+           (->* (baseline-machine? (vectorof value?))
+                ((or/c (vectorof any/c) boolean?))
+                (vectorof any/c))]
+          [baseline-profile (-> baseline-machine? symbol? any/c)])
          (struct-out discretization)
          (struct-out exn:rival)
          (struct-out exn:rival:invalid)
@@ -108,7 +117,7 @@
          *rival-use-shorthands*
          *rival-name-constants*
          (struct-out execution)
-         (contract-out [rival-profile (-> rival-machine? symbol? any/c)]))
+         (contract-out))
 
 (require "utils.rkt")
 (provide flonum-discretization

--- a/main.rkt
+++ b/main.rkt
@@ -102,6 +102,10 @@
           [rival-profile (-> rival-machine? symbol? any/c)]
           [baseline-compile
            (-> (listof any/c) (listof symbol?) (listof discretization?) baseline-machine?)]
+          [baseline-analyze
+           (->* (baseline-machine? (vectorof ival?))
+                ((or/c (vectorof any/c) boolean?))
+                (listof any/c))]
           [baseline-apply
            (->* (baseline-machine? (vectorof value?))
                 ((or/c (vectorof any/c) boolean?))

--- a/time.rkt
+++ b/time.rkt
@@ -12,8 +12,7 @@
          "test.rkt"
          "profile.rkt"
          "eval/machine.rkt" ; for accessing iteration number of machine
-         "infra/run-sollya.rkt"
-         "infra/run-baseline.rkt")
+         "infra/run-sollya.rkt")
 
 (define sample-vals (make-parameter 5000))
 (define *sampling-timeout* (make-parameter 20.0)) ; this parameter is used for plots generation

--- a/time.rkt
+++ b/time.rkt
@@ -143,8 +143,9 @@
             (define exs (vector-ref (baseline-apply baseline-machine (list->vector (map bf pt))) 1))
             (list 'valid exs))))
       (define baseline-apply-time (- (current-inexact-milliseconds) baseline-start-apply))
-      (define baseline-precision (baseline-machine-precision baseline-machine))
+      (define baseline-precision (baseline-profile baseline-machine 'precision))
       (define baseline-executions (baseline-profile baseline-machine 'executions))
+      (define baseline-iteration (baseline-profile baseline-machine 'iteration))
 
       ; Store histograms data
       (when (> rival-iter 0)
@@ -158,6 +159,21 @@
           (timeline-push! timeline
                           'mixsample-baseline-all
                           (list (execution-time execution) name precision))))
+
+      ; Record the percentage of instructions has been executed
+      (when (equal? baseline-status 'valid)
+        (define baseline-no-repeats-instr-cnt
+          (* (+ 1 baseline-iteration)
+             (vector-length (baseline-machine-instructions baseline-machine))))
+        (define baseline-instr-cnt (vector-length baseline-executions))
+        ; Report instruction that has been executed
+        (timeline-push! timeline
+                        'instr-executed-cnt
+                        (list 'baseline baseline-iteration baseline-instr-cnt))
+        ; Report the total number of instruction that could be executed with no repeats
+        (timeline-push! timeline
+                        'instr-executed-cnt
+                        (list 'baseline-no-repeats baseline-iteration baseline-no-repeats-instr-cnt)))
 
       ; --------------------------- Sollya execution ------------------------------------------------
       ; Points for expressions where Sollya has not compiled do not go to the plot/speed graphs!


### PR DESCRIPTION
This PR adds the following features to "Baseline":
1) Hint support, this is done in order to compare Rival and Baseline performances on Herbie's main. Currently main _supports_ hints, therefore, for a fair comparison it is necessary.
2) Including *useful?* feature to Baseline. The feature allows to skip reevaluating fixed intervals. The feature is originally from Rival's backward pass, however, it has less something to do with the tuning algorithm and probably can be added to Baseline as well in order to compare two tuning algorithms fairly.
3) Since adding *useful?* feature to Baseline, it means that Baseline also has some `adjust` time now, therefore, **histogram** plots were updated so that Baseline would also have a tuning column + **repeat** plot got updated since Baseline now also skips some instructions.
4) Other than that, PR removes some useless lines of code from Rival's pipeline which will speedup performance a little bit. A lot of code has been copied from Rival to Baseline, but it is fine as long as it is does not mess up Rival's code