### PR TITLE
Parsing optimization of `pow E x` to `exp x`

### DIFF
--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -125,6 +125,7 @@
     [`(pow ,arg 1/3) `(cbrt ,arg)]
     [`(pow ,arg 1/2) `(sqrt ,arg)]
     [`(pow 2 ,arg) `(exp2 ,arg)]
+    [`(pow (E) ,arg) `(exp ,arg)]
 
     ; Special trigonometric functions
     [`(cos (* ,(or 'PI '(PI)) (/ ,x ,(? (conjoin fixnum? positive?) n))))


### PR DESCRIPTION
That's slightly crazy to think, but an optimization as `(pow (E) x)` -> `(exp x)` can be very critical in performance.
This issue was discovered in Herbie, here are two screenshots of with and without the rewrite.
And all this is for just a simple benchmark `Logarithmic Transform`:
```
(FPCore (c x y)
 :precision binary64
 (* c (log (+ 1.0 (* (- (pow E x) 1.0) y)))))
```
![image](https://github.com/user-attachments/assets/400ddb23-ef50-4e17-b66a-03be6599f309)
![image](https://github.com/user-attachments/assets/0a31ff30-5c0a-4539-9234-fda638341393)
