### PR TITLE
Cleanup of "constant skips"

### DIFF
--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -124,7 +124,7 @@
                #t])]
            [else ; at this point we are given that the current instruction should be executed
             (define srcs
-              (drop-self-pointers (rest instr)
+              (drop-self-pointer (rest instr)
                                   (+ n
                                      varc))) ; then, children instructions should be executed as well
             (for-each (λ (x) (vhint-set! x #t)) srcs)
@@ -172,7 +172,7 @@
     (cond
       [(and (ival-lo-fixed? reg) (ival-hi-fixed? reg)) (vector-set! vrepeats i #t)]
       [else
-       (for ([arg (in-list (drop-self-pointers (cdr instr) (+ i varc)))]
+       (for ([arg (in-list (drop-self-pointer (cdr instr) (+ i varc)))]
              #:when (>= arg varc))
          (vector-set! vrepeats (- arg varc) #f))]))
 
@@ -193,7 +193,7 @@
           [n (in-naturals)]
           #:unless result-is-exact-already)
       ; check whether precision has increased
-      (define tail-registers (drop-self-pointers (cdr instr) (+ n varc)))
+      (define tail-registers (drop-self-pointer (cdr instr) (+ n varc)))
       (define precision-has-not-increased
         (and (<= prec-new (if constant? best-known-precision prec-old))
              (andmap (lambda (x) (or (< x varc) (vector-ref vrepeats (- x varc)))) tail-registers)))
@@ -223,7 +223,7 @@
   (vector-copy! vprecs 0 vprecs-new))
 
 ; Usually, add-bang instructions have a pointer to itself that is needed to be dropped
-(define (drop-self-pointers tail-regs n)
+(define (drop-self-pointer tail-regs n)
   (if (empty? tail-regs)
       tail-regs
       (if (equal? (car tail-regs) n)
@@ -243,7 +243,7 @@
         [output (in-vector vregs (- (vector-length vregs) 1) -1 -1)]
         #:when (and hint (not repeat?)))
     (define op (car instr))
-    (define tail-registers (drop-self-pointers (cdr instr) n))
+    (define tail-registers (drop-self-pointer (cdr instr) n))
     (define srcs (map (lambda (x) (vector-ref vregs x)) tail-registers))
 
     (define max-prec (vector-ref vprecs-max (- n varc))) ; upper precision bound given from parent

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -197,9 +197,11 @@
         (and (<= prec-new (if constant? best-known-precision prec-old))
              (andmap (lambda (x) (or (< x varc) (vector-ref vrepeats (- x varc)))) tail-registers)))
       ; update constant precision
-      (when constant?
-        (vector-set! vbest-precs n (max prec-new best-known-precision)))
-      (set! any-reevaluation? (or any-reevaluation? (not precision-has-not-increased)))
+      (define precision-has-increased (not precision-has-not-increased))
+      (when (and constant? precision-has-increased)
+        (vector-set! vbest-precs n prec-new))
+      (set! any-reevaluation? (or any-reevaluation? precision-has-increased))
+
       (vector-set! vrepeats n precision-has-not-increased))
     any-reevaluation?)
   (define any-reevaluation? (repeats))

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -167,10 +167,11 @@
   (for ([reg (in-vector vregs (- (vector-length vregs) 1) (- varc 1) -1)]
         [instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)]
         [i (in-range (- (vector-length ivec) 1) -1 -1)]
-        [repeat? (in-vector vrepeats (- (vector-length vrepeats) 1) -1 -1)])
+        [repeat? (in-vector vrepeats (- (vector-length vrepeats) 1) -1 -1)]
+        #:unless vrepeats)
     (cond
       [(and (ival-lo-fixed? reg) (ival-hi-fixed? reg)) (vector-set! vrepeats i #t)]
-      [(not repeat?)
+      [else
        (for ([arg (in-list (drop-self-pointers (cdr instr) (+ i varc)))]
              #:when (>= arg varc))
          (vector-set! vrepeats (- arg varc) #f))]))
@@ -200,8 +201,8 @@
       (define precision-has-increased (not precision-has-not-increased))
       (when (and constant? precision-has-increased)
         (vector-set! vbest-precs n prec-new))
-
       (set! any-reevaluation? (or any-reevaluation? precision-has-increased))
+
       (vector-set! vrepeats n precision-has-not-increased))
     any-reevaluation?)
   (define any-reevaluation? (repeats))

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -222,8 +222,13 @@
   ; Step 5. Copying new precisions into vprecs
   (vector-copy! vprecs 0 vprecs-new))
 
+; Usually, add-bang instructions have a pointer to itself that is needed to be dropped
 (define (drop-self-pointers tail-regs n)
-  (filter (λ (x) (not (equal? x n))) tail-regs))
+  (if (empty? tail-regs)
+      tail-regs
+      (if (equal? (car tail-regs) n)
+          (cdr tail-regs)
+          tail-regs)))
 
 ; This function goes through ivec and vregs and calculates (+ ampls base-precisions) for each operator in ivec
 ; Roughly speaking, the upper precision bound is calculated as:
@@ -235,11 +240,11 @@
         [repeat? (in-vector vrepeats (- (vector-length vrepeats) 1) -1 -1)]
         [n (in-range (- (vector-length vregs) 1) -1 -1)]
         [hint (in-vector vhint (- (vector-length vhint) 1) -1 -1)]
+        [output (in-vector vregs (- (vector-length vregs) 1) -1 -1)]
         #:when (and hint (not repeat?)))
     (define op (car instr))
     (define tail-registers (drop-self-pointers (cdr instr) n))
     (define srcs (map (lambda (x) (vector-ref vregs x)) tail-registers))
-    (define output (vector-ref vregs n))
 
     (define max-prec (vector-ref vprecs-max (- n varc))) ; upper precision bound given from parent
     (define min-prec (vector-ref vprecs-min (- n varc))) ; lower precision bound given from parent

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -168,7 +168,7 @@
         [instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)]
         [i (in-range (- (vector-length ivec) 1) -1 -1)]
         [repeat? (in-vector vrepeats (- (vector-length vrepeats) 1) -1 -1)]
-        #:unless vrepeats)
+        #:unless repeat?)
     (cond
       [(and (ival-lo-fixed? reg) (ival-hi-fixed? reg)) (vector-set! vrepeats i #t)]
       [else

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -197,11 +197,9 @@
         (and (<= prec-new (if constant? best-known-precision prec-old))
              (andmap (lambda (x) (or (< x varc) (vector-ref vrepeats (- x varc)))) tail-registers)))
       ; update constant precision
-      (define precision-has-increased (not precision-has-not-increased))
-      (when (and constant? precision-has-increased)
-        (vector-set! vbest-precs n prec-new))
-      (set! any-reevaluation? (or any-reevaluation? precision-has-increased))
-
+      (when constant?
+        (vector-set! vbest-precs n (max prec-new best-known-precision)))
+      (set! any-reevaluation? (or any-reevaluation? (not precision-has-not-increased)))
       (vector-set! vrepeats n precision-has-not-increased))
     any-reevaluation?)
   (define any-reevaluation? (repeats))

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -144,7 +144,7 @@
   (define vinitial-repeats (rival-machine-initial-repeats machine))
   (define vprecs (rival-machine-precisions machine))
   (define vstart-precs (rival-machine-initial-precisions machine))
-  (define vbest-precs (rival-machine-best-precision-known machine))
+  (define vbest-precs (rival-machine-best-known-precisions machine))
   (define current-iter (rival-machine-iteration machine))
   (define bumps (rival-machine-bumps machine))
 

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -125,8 +125,7 @@
            [else ; at this point we are given that the current instruction should be executed
             (define srcs
               (drop-self-pointer (rest instr)
-                                  (+ n
-                                     varc))) ; then, children instructions should be executed as well
+                                 (+ n varc))) ; then, children instructions should be executed as well
             (for-each (λ (x) (vhint-set! x #t)) srcs)
             #t])]))
     (vector-set! vhint n hint*))

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -290,11 +290,11 @@
 
   (define precisions (make-vector ivec-length)) ; vector that stores working precisions
   (define initial-precisions (setup-vstart-precs instructions num-vars roots discs))
+  (define best-known-precisions (make-vector ivec-length 0)) ; vector stores precisions of constants
 
   (define repeats (make-vector ivec-length #f)) ; flags whether an op should be evaluated
-  (define best-precision-known (make-vector ivec-length 0))
   (define initial-repeats
-    (make-initial-repeats instructions num-vars registers initial-precisions best-precision-known))
+    (make-initial-repeats instructions num-vars registers initial-precisions best-known-precisions))
 
   ; default hint (everything should be reexecuted)
   (define default-hint (make-vector (vector-length instructions) #t))
@@ -308,7 +308,7 @@
                  initial-repeats
                  precisions
                  initial-precisions
-                 best-precision-known
+                 best-known-precisions
                  (make-vector (vector-length roots))
                  default-hint
                  0

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -30,7 +30,7 @@
                    initial-repeats
                    precisions
                    initial-precisions
-                   best-precision-known
+                   best-known-precisions
                    output-distance
                    default-hint
                    [iteration #:mutable]

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -27,10 +27,11 @@
                    discs
                    registers
                    repeats
+                   initial-repeats
                    precisions
-                   incremental-precisions
+                   initial-precisions
+                   best-precision-known
                    output-distance
-                   initial-precision
                    default-hint
                    [iteration #:mutable]
                    [bumps #:mutable]

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -85,7 +85,7 @@
 ; Output: '( '(upper-ampl-bound lower-ampl-bound) ...) with len(srcs) number of elements
 (define (get-bounds op z srcs)
   (case (object-name op)
-    [(ival-mult)
+    [(ival-mult ival-mult!)
      ; Γ[*]'x     = 1
      ; ↑ampl[*]'x = logspan(y)
      ; ↓ampl[*]'x = 0
@@ -98,14 +98,7 @@
      (list (cons (logspan y) 0) ; bounds per x
            (cons (logspan x) 0))] ; bounds per y
 
-    [(ival-mult!)
-     ; Same as above, ignoring output register
-     (match-define (list _ x y) srcs)
-     (list (cons 0 0) ; Ignore output register
-           (cons (logspan y) 0) ; bounds per x
-           (cons (logspan x) 0))] ; bounds per y
-
-    [(ival-div)
+    [(ival-div ival-div!)
      ; Γ[/]'x     = 1
      ; ↑ampl[/]'x = logspan(y)
      ; ↓ampl[/]'x = 0
@@ -116,12 +109,6 @@
      (define x (first srcs))
      (define y (second srcs))
      (list (cons (logspan y) 0) ; bounds per x
-           (cons (+ (logspan x) (* 2 (logspan y))) 0))] ; bounds per y
-
-    [(ival-div!)
-     (match-define (list _ x y) srcs)
-     (list (cons 0 0)
-           (cons (logspan y) 0) ; bounds per x
            (cons (+ (logspan x) (* 2 (logspan y))) 0))] ; bounds per y
 
     [(ival-sqrt ival-cbrt)
@@ -135,7 +122,7 @@
      (define x (first srcs))
      (list (cons (quotient (logspan x) 2) 0))]
 
-    [(ival-add ival-sub)
+    [(ival-add ival-sub ival-add! ival-sub!)
      ; Γ[+ & -]'x     = |x/(x+y)| & |x/(x-y)|
      ; ↑ampl[+ & -]'x = maxlog(x) - minlog(z)
      ; ↓ampl[+ & -]'x = minlog(x) - maxlog(z)
@@ -152,19 +139,6 @@
                (cons (- (maxlog y) (minlog z))
                      (- (minlog y #:less-slack #t) (maxlog z #:less-slack #t)))) ; bounds per y
          (list (cons (- (maxlog x) (minlog z)) 0) ; bounds per x
-               (cons (- (maxlog y) (minlog z)) 0)))] ; bounds per y
-
-    [(ival-add! ival-sub!)
-     (match-define (list _ x y) srcs)
-
-     (if (*lower-bound-early-stopping*)
-         (list (cons 0 0)
-               (cons (- (maxlog x) (minlog z))
-                     (- (minlog x #:less-slack #t) (maxlog z #:less-slack #t))) ; bounds per x
-               (cons (- (maxlog y) (minlog z))
-                     (- (minlog y #:less-slack #t) (maxlog z #:less-slack #t)))) ; bounds per y
-         (list (cons 0 0)
-               (cons (- (maxlog x) (minlog z)) 0) ; bounds per x
                (cons (- (maxlog y) (minlog z)) 0)))] ; bounds per y
 
     [(ival-pow)

--- a/infra/repeats_plot.py
+++ b/infra/repeats_plot.py
@@ -28,7 +28,6 @@ def plot_repeats_plot(outcomes, args):
     average_baseline = round((1.0 - (baseline['number_of_instr_executions'].sum() / baseline_no_repeats['number_of_instr_executions'].sum())) * 100, 2)
     print("\\newcommand{\\AveragePercentageOfSkippedInstrBaseline}{" + str(average_baseline) + "}")
 
-    print(rival['number_of_instr_executions'].sum(), baseline['number_of_instr_executions'].sum())
     rival_evaluates_less_instructions = round((baseline['number_of_instr_executions'].sum() - rival['number_of_instr_executions'].sum()) / baseline['number_of_instr_executions'].sum() * 100, 2)
     print("\\newcommand{\\RivalInstrCountLessThanBaseline}{" + str(rival_evaluates_less_instructions) + "}")
 

--- a/infra/run-baseline.rkt
+++ b/infra/run-baseline.rkt
@@ -22,7 +22,7 @@
                    discs
                    registers
                    precisions
-                   best-precision-known
+                   best-known-precisions
                    repeats
                    initial-repeats
                    default-hint
@@ -163,10 +163,12 @@
   (define start-prec (+ (discretization-target (last discs)) 10))
   (define precisions
     (make-vector (- register-count num-vars) start-prec)) ; vector that stores working precisions
+  (define best-known-precisions (make-vector (- register-count num-vars) 0)) ; for constant ops
+
   (define repeats (make-vector (- register-count num-vars)))
-  (define best-precision-known (make-vector (- register-count num-vars) 0))
   (define initial-repeats
-    (make-initial-repeats instructions num-vars registers precisions best-precision-known))
+    (make-initial-repeats instructions num-vars registers precisions best-known-precisions))
+
   (define default-hint (make-vector (- register-count num-vars) #t))
 
   (baseline-machine (list->vector vars)
@@ -175,7 +177,7 @@
                     discs
                     registers
                     precisions
-                    best-precision-known
+                    best-known-precisions
                     repeats
                     initial-repeats
                     default-hint
@@ -233,7 +235,7 @@
       (define rootvec (baseline-machine-outputs machine))
       (define vrepeats (baseline-machine-repeats machine))
       (define args (baseline-machine-arguments machine))
-      (define vbest-precs (baseline-machine-best-precision-known machine))
+      (define vbest-precs (baseline-machine-best-known-precisions machine))
       (define vinitial-repeats (baseline-machine-initial-repeats machine))
       (define varc (vector-length args))
       (define vuseful (make-vector (vector-length ivec) #f))


### PR DESCRIPTION
This PR resolves a confusion of using `hint` mechanism for _constant_ subexpressions evaluation skips.

Particularly speaking, it was decided that _constant skips_ have more to do with `repeats` rather then `hint`.
This PR implements it by changing `rival-machine` structure by a little:
We need new features of the `machine`, such as: `initial-repeats` vector which would point which instructions should be skipped at the initial iteration; additionally, we need a vector that would store the maximum precisions constant operations got evaluated under - this info will go into `backward-pass`

Additionally, this PR gets rid of `vuseful` vector which used to be created at each tuning  pass. 
Turned out, that the _useful_ logic can be associated with `vrepeats` vector - which is already allocated