### PR TITLE
Sollya caching

### DIFF
--- a/infra/nightly.sh
+++ b/infra/nightly.sh
@@ -57,8 +57,8 @@ function all {
 
 function perf {
     clean
-    xz -d -k -f infra/points.json.xz
-    racket -y time.rkt --dir "$REPORTDIR" --profile profile.json infra/points.json
+    xz -d -k -f infra/new_points.json.xz
+    racket -y time.rkt --dir "$REPORTDIR" --profile profile.json infra/new_points.json
     python3 infra/ratio_plot.py -t "$REPORTDIR"/timeline.json -o "$REPORTDIR"
     python3 infra/point_graph.py -t "$REPORTDIR"/timeline.json -o "$REPORTDIR"
     python3 infra/histograms.py -t "$REPORTDIR"/timeline.json -o "$REPORTDIR"

--- a/time.rkt
+++ b/time.rkt
@@ -194,12 +194,20 @@
         (set! sollya-exs
               (match sollya-exs
                 ["#f" #f]
+                [#f #f]
                 [_ (fl (string->number sollya-exs))]))
 
         (set! sollya-status
               (match sollya-status
-                ["#f" #f]
+                ["#f" 'invalid]
+                [#f 'invalid]
                 [_ (string->symbol sollya-status)]))
+
+        (set! sollya-apply-time
+              (match sollya-apply-time
+                ["#f" 0.0]
+                [#f 0.0]
+                [_ sollya-apply-time]))
 
         ; -------------------------------- Combining results ----------------------------------------
         ; When all the machines have compiled and produced results - write the results to outcomes

--- a/time.rkt
+++ b/time.rkt
@@ -15,7 +15,7 @@
          "infra/run-sollya.rkt")
 
 (define sample-vals (make-parameter 5000))
-(define *sampling-timeout* (make-parameter 100.0)) ; this parameter is used for plots generation
+(define *sampling-timeout* (make-parameter 20.0)) ; this parameter is used for plots generation
 
 ; These parameters are used for latex data
 (define *num-tuned-benchmarks* (make-parameter 0))


### PR DESCRIPTION
This PR caches Sollya's results which makes nightlies way faster.
The key insight is that Sollya's results do not change from run to run as we do not modify it.
Therefore, the evaluation results can be cached. 

Sollya has been run with timeout 100ms and the results has been stored in `infra/points.json`.
With the cache, every point in `infra/points.json` has a format of `(list pt sollya-exs sollya-status sollya-apply-time)`.

Caching in action: [`report`](https://nightly.cs.washington.edu/reports/rival/1744162721:sollya-caching:e645c511/)