### PR TITLE
Allow 0^-0 not to be a must-error

### DIFF
--- a/ops/pow.rkt
+++ b/ops/pow.rkt
@@ -100,10 +100,14 @@
          (values real-lo! real-hi!)]
         [else (values lo! hi!)]))
 
+    (eprintf "pos x ~a y ~a lo ~a hi ~a\n" x-class y-class lo hi)
+
     (ival (endpoint lo real-lo!)
           (endpoint hi real-hi!)
           (or xerr? yerr? (and (bfzero? (endpoint-val xlo)) (not (= y-class 1))))
-          (or xerr yerr (and (bfzero? (endpoint-val xhi)) (= y-class -1)))))
+          (or xerr yerr (and (bfzero? (endpoint-val xhi))
+                             (= y-class -1)
+                             (not (bfzero? (endpoint-val yhi)))))))
 
   (match* (x-class y-class)
     [(1 1) (mk-pow xlo ylo xhi yhi)]


### PR DESCRIPTION
This PR fixes #104 by allowing 0^-0 to not be a must-error; previously, 0^-0 was illegal (because the exponent was judged to be negative) but now it's legal (and equal to 1).