### PR TITLE
Fix pretty subtle "bug" #110 in `fmod`

### DIFF
--- a/eval/tests.rkt
+++ b/eval/tests.rkt
@@ -102,13 +102,17 @@
       ; A little hack, the analyze below uses hint from the previous run
       ; The analyze results must be equal. If not, something wrong has happened
       (match-define (list res* hint* converged?*) (rival-analyze machine hyperrect hint))
-      (check-equal? hint hint*)
-      (check-equal? res res*)
-      (check-equal? converged? converged?*)
+
+      (with-check-info (['hyperrect hyperrect] ['hint hint])
+        (check-equal? hint hint*)
+        (check-equal? res res*)
+        (check-equal? converged? converged?*))
 
       (for ([_ (in-range number-of-random-pts-per-rect)])
         (define pt (sample-pts hyperrect))
-        (define-values (no-hint-cnt* hint-cnt*) (rival-check-hint machine hint pt))
+        (define-values (no-hint-cnt* hint-cnt*)
+          (with-check-info (['pt pt] ['hint hint])
+            (rival-check-hint machine hint pt)))
         (set! hint-cnt (+ hint-cnt hint-cnt*))
         (set! no-hint-cnt (+ no-hint-cnt no-hint-cnt*))))
     (define skipped-percentage (* (/ hint-cnt no-hint-cnt) 100))
@@ -119,7 +123,9 @@
     (define vars '(x y))
     (define varc (length vars))
     (define machine (rival-compile expressions vars discs))
-    (define skipped-instr (hints-random-checks machine (first rect) (second rect) varc))
+    (define skipped-instr
+      (with-check-info (['expressions expressions])
+        (hints-random-checks machine (first rect) (second rect) varc)))
     (check-true (< skipped-instr 99)
                 (format "Almost no instructions got skipped by hint at ~a" expressions)))
 

--- a/eval/tests.rkt
+++ b/eval/tests.rkt
@@ -104,15 +104,14 @@
       (match-define (list res* hint* converged?*) (rival-analyze machine hyperrect hint))
 
       (with-check-info (['hyperrect hyperrect] ['hint hint])
-        (check-equal? hint hint*)
-        (check-equal? res res*)
-        (check-equal? converged? converged?*))
+                       (check-equal? hint hint*)
+                       (check-equal? res res*)
+                       (check-equal? converged? converged?*))
 
       (for ([_ (in-range number-of-random-pts-per-rect)])
         (define pt (sample-pts hyperrect))
         (define-values (no-hint-cnt* hint-cnt*)
-          (with-check-info (['pt pt] ['hint hint])
-            (rival-check-hint machine hint pt)))
+          (with-check-info (['pt pt] ['hint hint]) (rival-check-hint machine hint pt)))
         (set! hint-cnt (+ hint-cnt hint-cnt*))
         (set! no-hint-cnt (+ no-hint-cnt no-hint-cnt*))))
     (define skipped-percentage (* (/ hint-cnt no-hint-cnt) 100))
@@ -125,7 +124,7 @@
     (define machine (rival-compile expressions vars discs))
     (define skipped-instr
       (with-check-info (['expressions expressions])
-        (hints-random-checks machine (first rect) (second rect) varc)))
+                       (hints-random-checks machine (first rect) (second rect) varc)))
     (check-true (< skipped-instr 99)
                 (format "Almost no instructions got skipped by hint at ~a" expressions)))
 

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -241,7 +241,7 @@
   (define err (or (or xerr (bflt? xhi lo) (bfgt? xlo hi))))
 
   (if (and (bfzero? lo) (bfzero? xhi))
-      (ival (endpoint 0.bf xlo!) (endpoint 0.bf xhi!) err? err)
+      (ival (endpoint (bf 0) xlo!) (endpoint (bf 0) xhi!) err? err)
       (ival (endpoint (if (bflt? xlo lo) lo xlo) xlo!)
             (endpoint (if (bfgt? xhi hi) hi xhi) xhi!)
             err?
@@ -301,7 +301,7 @@
     [1 ((monotonic bfabs) x)]
     [0
      (match-define (ival (endpoint xlo xlo!) (endpoint xhi xhi!) xerr? xerr) x)
-     (ival (endpoint 0.bf (and xlo! xhi!))
+     (ival (endpoint (bf 0) (and xlo! xhi!))
            (rnd 'up endpoint-max2 (epfn bfabs (ival-lo x)) (ival-hi x))
            (ival-err? x)
            (ival-err x))]))
@@ -384,10 +384,10 @@
            (endpoint (rnd 'up pi.bf) #f)
            (or err? (bfgte? (ival-hi-val x) 0.bf))
            (or err
-               (and (bf=? (ival-lo-val x) 0.bf)
-                    (bf=? (ival-hi-val x) 0.bf)
-                    (bf=? (ival-lo-val y) 0.bf)
-                    (bf=? (ival-hi-val y) 0.bf))))]))
+               (and (bfzero? (ival-lo-val x))
+                    (bfzero? (ival-hi-val x))
+                    (bfzero? (ival-lo-val y))
+                    (bfzero? (ival-hi-val y)))))]))
 
 (define*
  ival-cosh


### PR DESCRIPTION
Basically, the `fmod` code sometimes involves calling `fabs` and it also sometimes depends on the precision of its arguments for intermediate computations. But it turns out that `fabs` sometimes returns 0 (for intervals that cross 0) and this 0 is the wrong precision (too high), which breaks refinement. The solution is to make a `0` of the correct precision.