### PR TITLE
Adding tuning formulas for `tanu`, `cosu` and `sinu`, fix #112

### DIFF
--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -227,7 +227,7 @@
     ; clean progress of the current tuning pass and start over
     (vector-fill! vprecs-new 0)
     (vector-fill! vrepeats #f)
-    (precision-tuning ivec vregs vprecs-new varc vstart-precs vrepeats vhint)
+    (precision-tuning ivec vregs vprecs-new varc vstart-precs vrepeats vhint constants-lookup)
     (repeats)) ; do repeats again
 
   ; Step 5. Copying new precisions into vprecs

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -33,6 +33,7 @@
                    best-known-precisions
                    output-distance
                    default-hint
+                   constant-lookup
                    [iteration #:mutable]
                    [bumps #:mutable]
                    [profile-ptr #:mutable]

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -388,18 +388,16 @@
      ; ↑ampl[cosu]'x = ↑ampl[cosu]'n = maxlog(x) - minlog(n) - minlog(z) + 2 (accounting for pi)
      ; ↓ampl[cosu]'x = ↓ampl[cosu]'n = 0 <-- maybe can be better
      (define x (first srcs))
-     (define n (second srcs))
-     (list (make-list 2 (cons (- (maxlog x) (minlog n) (minlog z) -2) 0)))]
+     (define n (second srcs)) ; n is already a floor(log(n))
+     (list (cons (- (maxlog x) n (minlog z) -2) 0))]
 
     [(ival-tanu)
      ; Γ[tanu]'x = |x*pi/n * (1 / cos^2(x*pi/n)) / tan(x*pi/n)|
      ; ↑ampl[tanu]'x = ↑ampl[tanu]'n = maxlog(x) - minlog(n) + max(|minlog(z)|, |maxlog(z)|) + 3 (accounting for pi)
      ; ↓ampl[tanu]'x = ↓ampl[tanu]'n = 0 <-- maybe can be better
      (define x (first srcs))
-     (define n (second srcs))
-     (list (make-list 2
-                      (cons (- (maxlog x) (minlog n) (- (max (abs (maxlog z)) (abs (minlog z)))) -3)
-                            0)))]
+     (define n (second srcs)) ; n is already a floor(log(n))
+     (list (cons (- (maxlog x) n (- (max (abs (maxlog z)) (abs (minlog z)))) -3) 0))]
 
     ; TODO
     ; ↑ampl[...] = slack

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -378,6 +378,29 @@
      (define x (first srcs))
      (list (cons (+ (logspan x) 1) 0))]
 
+    [(ival-sinu ival-cosu)
+     ; Γ[sinu]'x = |x*pi/n * cos(x*pi/n) / sin(x*pi/n)|
+     ; Γ[cosu]'x = |x*pi/n * sin(x*pi/n) / cos(x*pi/n)|
+     ;
+     ; ↑ampl[sinu]'x = ↑ampl[sinu]'n = maxlog(x) - minlog(n) - minlog(z) + 2 (accounting for pi)
+     ; ↓ampl[sinu]'x = ↓ampl[sinu]'n = 0 <-- maybe can be better
+     ;
+     ; ↑ampl[cosu]'x = ↑ampl[cosu]'n = maxlog(x) - minlog(n) - minlog(z) + 2 (accounting for pi)
+     ; ↓ampl[cosu]'x = ↓ampl[cosu]'n = 0 <-- maybe can be better
+     (define x (first srcs))
+     (define n (second srcs))
+     (list (make-list 2 (cons (- (maxlog x) (minlog n) (minlog z) -2) 0)))]
+
+    [(ival-tanu)
+     ; Γ[tanu]'x = |x*pi/n * (1 / cos^2(x*pi/n)) / tan(x*pi/n)|
+     ; ↑ampl[tanu]'x = ↑ampl[tanu]'n = maxlog(x) - minlog(n) + max(|minlog(z)|, |maxlog(z)|) + 3 (accounting for pi)
+     ; ↓ampl[tanu]'x = ↓ampl[tanu]'n = 0 <-- maybe can be better
+     (define x (first srcs))
+     (define n (second srcs))
+     (list (make-list 2
+                      (cons (- (maxlog x) (minlog n) (- (max (abs (maxlog z)) (abs (minlog z)))) -3)
+                            0)))]
+
     ; TODO
     ; ↑ampl[...] = slack
     ; ↓ampl[...] = 0

--- a/eval/tricks.rkt
+++ b/eval/tricks.rkt
@@ -387,16 +387,16 @@
      ;
      ; ↑ampl[cosu]'x = ↑ampl[cosu]'n = maxlog(x) - minlog(n) - minlog(z) + 2 (accounting for pi)
      ; ↓ampl[cosu]'x = ↓ampl[cosu]'n = 0 <-- maybe can be better
-     (define x (first srcs))
-     (define n (second srcs)) ; n is already a floor(log(n))
+     (define x (car srcs))
+     (define n (cdr srcs)) ; n is already a floor(log(n))
      (list (cons (- (maxlog x) n (minlog z) -2) 0))]
 
     [(ival-tanu)
      ; Γ[tanu]'x = |x*pi/n * (1 / cos^2(x*pi/n)) / tan(x*pi/n)|
      ; ↑ampl[tanu]'x = ↑ampl[tanu]'n = maxlog(x) - minlog(n) + max(|minlog(z)|, |maxlog(z)|) + 3 (accounting for pi)
      ; ↓ampl[tanu]'x = ↓ampl[tanu]'n = 0 <-- maybe can be better
-     (define x (first srcs))
-     (define n (second srcs)) ; n is already a floor(log(n))
+     (define x (car srcs))
+     (define n (cdr srcs)) ; n is already a floor(log(n))
      (list (cons (- (maxlog x) n (- (max (abs (maxlog z)) (abs (minlog z)))) -3) 0))]
 
     ; TODO


### PR DESCRIPTION
This PR introduces changes to Rival's exponent tricks.
Particularly speaking, tuning formulas for `tanu`, `cosu` and `sinu` have been added.
It is quite interesting that we never ran into this before. One of the reasons why is that Linux uses an older version of MPFR - and we mostly use Linux.
The bug was discovered by @JonasRegehr when using Rival on MacOS.
The new exponent tricks are pretty straight forward, but the fact that the angle for `tanu`, etc. is not stored as an `ival` makes the code slightly tricky, as this angle needs to be stored somewhere since it participates in precision tuning.
I store this angle constant into a new `rival-machine` field called `constant-lookup` - this is a vector to where we can add constants like this now on that do not participate in evaluation, but do participate in precision tuning.