### PR TITLE
Document that `ival-fmod` and `ival-remainder` fail refinement

### DIFF
--- a/ops/fmod.rkt
+++ b/ops/fmod.rkt
@@ -16,11 +16,11 @@
 ;; (define x
 ;;   (parameterize ([bf-precision 88])
 ;;     (ival (bf "2.023002359077489336695397166e258"))))
-;; 
+;;
 ;; (define y
 ;;   (parameterize ([bf-precision 91])
 ;;     (ival 0.bf (bf "6.4878140443992047719110337054e233"))))
-;; 
+;;
 ;; (define yhi
 ;;   (parameterize ([bf-precision 91])
 ;;     (ival 0.bf (bf "6.4878140443992047719110335995e233"))))
@@ -108,7 +108,8 @@
     (or (ival-err x) (ival-err y) (and (bf=? (ival-lo-val y) 0.bf) (bf=? (ival-hi-val y) 0.bf))))
   (define y* (ival-exact-fabs y))
   (cond
-    [(= (mpfr-sign (ival-hi-val x)) -1) (ival-neg (ival-remainder-pos (ival-exact-neg x) y* err? err))]
+    [(= (mpfr-sign (ival-hi-val x)) -1)
+     (ival-neg (ival-remainder-pos (ival-exact-neg x) y* err? err))]
     [(= (mpfr-sign (ival-lo-val x)) 1) (ival-remainder-pos x y* err? err)]
     [else
      (define-values (neg pos) (split-ival x 0.bf))

--- a/ops/fmod.rkt
+++ b/ops/fmod.rkt
@@ -12,44 +12,20 @@
 
 (define (ival-fmod-pos x y err? err)
   ;; Assumes both `x` and `y` are entirely positive
-  (define precision (max (bf-precision) (ival-max-prec x) (ival-max-prec y)))
-  (define a
-    (parameterize ([bf-precision precision])
-      (rnd 'down bftruncate (bfdiv (ival-lo-val x) (ival-hi-val y)))))
-  (define b
-    (parameterize ([bf-precision precision])
-      (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y)))))
+  (define a (rnd 'down bftruncate (bfdiv (ival-lo-val x) (ival-hi-val y))))
+  (define b (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y))))
   (cond
     [(bf=? a b) ; No intersection along `y.hi` edge
-     (define c
-       (parameterize ([bf-precision precision])
-         (rnd 'down bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y)))))
-     (define d
-       (parameterize ([bf-precision precision])
-         (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-lo-val y)))))
+     (define c (rnd 'down bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y))))
+     (define d (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-lo-val y))))
      (cond
        [(bf=? c d) ; No intersection along `x.hi` either; use top-left/bottom-right point
-        (define lo
-          (rnd 'down
-               bfsub
-               (ival-lo-val x)
-               (parameterize ([bf-precision precision])
-                 (rnd 'up bfmul* c (ival-hi-val y)))))
-        (define hi
-          (rnd 'up
-               bfsub
-               (ival-hi-val x)
-               (parameterize ([bf-precision precision])
-                 (rnd 'down bfmul* c (ival-lo-val y)))))
+        (define lo (rnd 'down bffmod (ival-lo-val x) (ival-hi-val y)))
+        (define hi (rnd 'up bffmod (ival-hi-val x) (ival-lo-val y)))
         (ival (endpoint lo #f) (endpoint hi #f) err? err)]
        [else
         (ival (endpoint 0.bf #f)
-              (endpoint (rnd 'up
-                             bfmax2
-                             (parameterize ([bf-precision precision])
-                               (bfdiv (ival-hi-val x) (rnd 'down bfadd c 1.bf)))
-                             0.bf)
-                        #f)
+              (endpoint (rnd 'up bfmax2 (bfdiv (ival-hi-val x) (rnd 'down bfadd c 1.bf)) 0.bf) #f)
               err?
               err)])]
     [else (ival (endpoint 0.bf #f) (endpoint (ival-hi-val y) #f) err? err)]))

--- a/ops/fmod.rkt
+++ b/ops/fmod.rkt
@@ -10,8 +10,34 @@
       0.bf
       (bfmul a b)))
 
+;; WARNING: double rounding issues below, it does not refine
+;;
+;;
+;; (define x
+;;   (parameterize ([bf-precision 88])
+;;     (ival (bf "2.023002359077489336695397166e258"))))
+;; 
+;; (define y
+;;   (parameterize ([bf-precision 91])
+;;     (ival 0.bf (bf "6.4878140443992047719110337054e233"))))
+;; 
+;; (define yhi
+;;   (parameterize ([bf-precision 91])
+;;     (ival 0.bf (bf "6.4878140443992047719110335995e233"))))
+;;
+;;
+;; Here yhi refines y, so you'd think fmod(x, yhi) refines fmod(x, y)
+;; but in fact it doesn't! Due to double-rounding, in fmox(x, y),
+;; we don't think there's an intersection along the top edge, but in
+;; fmod(x, yhi) we falsely do, which leads to a bigger interval.
+;;
+;; For this reason ival-fmod and ival-remainder skip refinement tests.
+;;
+;; Ideally we'd fix this and get even tighter bounds, but maybe it
+;; doesn't matter?
+
+;; Assumes both `x` and `y` are entirely positive
 (define (ival-fmod-pos x y err? err)
-  ;; Assumes both `x` and `y` are entirely positive
   (define a (rnd 'down bftruncate (bfdiv (ival-lo-val x) (ival-hi-val y))))
   (define b (rnd 'up bftruncate (bfdiv (ival-hi-val x) (ival-hi-val y))))
   (cond
@@ -25,7 +51,7 @@
         (ival (endpoint lo #f) (endpoint hi #f) err? err)]
        [else
         (ival (endpoint 0.bf #f)
-              (endpoint (rnd 'up bfmax2 (bfdiv (ival-hi-val x) (rnd 'down bfadd c 1.bf)) 0.bf) #f)
+              (endpoint (rnd 'up bfdiv (ival-hi-val x) (rnd 'down bfadd c 1.bf)) #f)
               err?
               err)])]
     [else (ival (endpoint 0.bf #f) (endpoint (ival-hi-val y) #f) err? err)]))
@@ -39,8 +65,8 @@
     (or (ival-err x) (ival-err y) (and (bf=? (ival-lo-val y) 0.bf) (bf=? (ival-hi-val y) 0.bf))))
   (define y* (ival-exact-fabs y))
   (cond
-    [(bflte? (ival-hi-val x) 0.bf) (ival-neg (ival-fmod-pos (ival-exact-neg x) y* err? err))]
-    [(bfgte? (ival-lo-val x) 0.bf) (ival-fmod-pos x y* err? err)]
+    [(= (mpfr-sign (ival-hi-val x)) -1) (ival-neg (ival-fmod-pos (ival-exact-neg x) y* err? err))]
+    [(= (mpfr-sign (ival-lo-val x)) 1) (ival-fmod-pos x y* err? err)]
     [else
      (define-values (neg pos) (split-ival x 0.bf))
      (ival-union (ival-fmod-pos pos y* err? err)
@@ -56,14 +82,9 @@
      (define d (rnd 'up bfround (bfdiv (ival-hi-val x) (ival-lo-val y))))
      (cond
        [(bf=? c d) ; No intersection along `x.hi` either; use top-left/bottom-right point
-        (define y* (rnd 'up bfdiv (ival-hi-val y) 2.bf))
-        (ival
-         (endpoint
-          (rnd 'down bfmax2 (bfsub (ival-lo-val x) (rnd 'up bfmul c (ival-hi-val y))) (bfneg y*))
-          #f)
-         (endpoint (rnd 'up bfmin2 (bfsub (ival-hi-val x) (rnd 'down bfmul c (ival-lo-val y))) y*) #f)
-         err?
-         err)]
+        (define lo (rnd 'down bfremainder (ival-lo-val x) (ival-hi-val y)))
+        (define hi (rnd 'up bfremainder (ival-hi-val x) (ival-lo-val y)))
+        (ival (endpoint lo #f) (endpoint hi #f) err? err)]
        [else
         ;; NOPE! need to subtract half.bf one way, add it another!
         (define y*-hi (rnd 'up bfdiv (bfdiv (ival-hi-val x) (rnd 'down bfadd c half.bf)) 2.bf))
@@ -87,8 +108,8 @@
     (or (ival-err x) (ival-err y) (and (bf=? (ival-lo-val y) 0.bf) (bf=? (ival-hi-val y) 0.bf))))
   (define y* (ival-exact-fabs y))
   (cond
-    [(bflte? (ival-hi-val x) 0.bf) (ival-neg (ival-remainder-pos (ival-exact-neg x) y* err? err))]
-    [(bfgte? (ival-lo-val x) 0.bf) (ival-remainder-pos x y* err? err)]
+    [(= (mpfr-sign (ival-hi-val x)) -1) (ival-neg (ival-remainder-pos (ival-exact-neg x) y* err? err))]
+    [(= (mpfr-sign (ival-lo-val x)) 1) (ival-remainder-pos x y* err? err)]
     [else
      (define-values (neg pos) (split-ival x 0.bf))
      (ival-union (ival-remainder-pos pos y* err? err)

--- a/scribblings/core.scrbl
+++ b/scribblings/core.scrbl
@@ -57,70 +57,6 @@ functions, which return different intervals at different
 
 @section{Interval Operations}
 
-@deftogether[(
-  @defproc[(ival-add [a ival?] [b ival?]) ival?]
-  @defproc[(ival-sub [a ival?] [b ival?]) ival?]
-  @defproc[(ival-neg [a ival?]) ival?]
-  @defproc[(ival-mul [a ival?] [b ival?]) ival?]
-  @defproc[(ival-div [a ival?] [b ival?]) ival?]
-  @defproc[(ival-fma [a ival?] [b ival?] [c ival?]) ival?]
-  @defproc[(ival-fabs [a ival?]) ival?]
-  @defproc[(ival-sqrt [a ival?]) ival?]
-  @defproc[(ival-cbrt [a ival?]) ival?]
-  @defproc[(ival-hypot [a ival?] [b ival?]) ival?]
-  @defproc[(ival-exp [a ival?]) ival?]
-  @defproc[(ival-exp2 [a ival?]) ival?]
-  @defproc[(ival-exp2m1 [a ival?]) ival?]
-  @defproc[(ival-log [a ival?]) ival?]
-  @defproc[(ival-log2 [a ival?]) ival?]
-  @defproc[(ival-log10 [a ival?]) ival?]
-  @defproc[(ival-log1p [a ival?]) ival?]
-  @defproc[(ival-logb [a ival?]) ival?]
-  @defproc[(ival-pow [a ival?] [b ival?]) ival?]
-  @defproc[(ival-sin [a ival?]) ival?]
-  @defproc[(ival-cos [a ival?]) ival?]
-  @defproc[(ival-tan [a ival?]) ival?]
-  @defproc[(ival-asin [a ival?]) ival?]
-  @defproc[(ival-acos [a ival?]) ival?]
-  @defproc[(ival-atan [a ival?]) ival?]
-  @defproc[(ival-atan2 [a ival?] [b ival?]) ival?]
-  @defproc[(ival-sinh [a ival?]) ival?]
-  @defproc[(ival-cosh [a ival?]) ival?]
-  @defproc[(ival-tanh [a ival?]) ival?]
-  @defproc[(ival-asinh [a ival?]) ival?]
-  @defproc[(ival-acosh [a ival?]) ival?]
-  @defproc[(ival-atanh [a ival?]) ival?]
-  @defproc[(ival-erf [a ival?]) ival?]
-  @defproc[(ival-erfc [a ival?]) ival?]
-  @defproc[(ival-tgamma [a ival?]) ival?]
-  @defproc[(ival-lgamma [a ival?]) ival?]
-  @defproc[(ival-fmod [a ival?] [b ival?]) ival?]
-  @defproc[(ival-remainder [a ival?] [b ival?]) ival?]
-  @defproc[(ival-rint [a ival?]) ival?]
-  @defproc[(ival-round [a ival?]) ival?]
-  @defproc[(ival-ceil [a ival?]) ival?]
-  @defproc[(ival-floor [a ival?]) ival?]
-  @defproc[(ival-trunc [a ival?]) ival?]
-  @defproc[(ival-fmin [a ival?] [b ival?]) ival?]
-  @defproc[(ival-fmax [a ival?] [b ival?]) ival?]
-  @defproc[(ival-copysign [a ival?] [b ival?]) ival?]
-  @defproc[(ival-fdim [a ival?] [b ival?]) ival?]
-)]{
-  These are all interval functions with arguments in the order
-  corresponding to the same-name @code{math.h} functions. The
-  precision of the output can be set with @racket[bf-precision].
-
-  @history[#:changed "1.7" @elem{Added @racket[ival-tgamma] and @racket[ival-lgamma]}]
-}
-
-@defproc[(ival-sort [lst (listof ival?)]
-                  [< (-> (or/c bigfloat? boolean?)
-                        (or/c bigfloat? boolean?)
-                        boolean?)])
-        (listof ival?)]{
-  Sorts a list of intervals using a comparator function.
-}
-
 Rival aims to ensure three properties of all helper functions:
 
 @itemlist[
@@ -145,56 +81,101 @@ Rival aims to ensure three properties of all helper functions:
 
 Weak completeness (tightness) is the strongest possible property,
 while soundness (validity) is the weakest, with refinement somewhere
-in between. Rival's interval functions offer the following guarantees:
+in between.
 
-@tabular[
-(list (list @racket[ival-add]       "tight")
-      (list @racket[ival-sub]       "tight")
-      (list @racket[ival-neg]       "tight")
-      (list @racket[ival-mul]       "tight")
-      (list @racket[ival-div]       "tight")
-      (list @racket[ival-fma]       "refinement")
-      (list @racket[ival-fabs]      "tight")
-      (list @racket[ival-sqrt]      "tight")
-      (list @racket[ival-cbrt]      "tight")
-      (list @racket[ival-hypot]     "tight")
-      (list @racket[ival-exp]       "tight")
-      (list @racket[ival-exp2]      "tight")
-      (list @racket[ival-exp2m1]    "tight")
-      (list @racket[ival-log]       "tight")
-      (list @racket[ival-log2]      "tight")
-      (list @racket[ival-log10]     "tight")
-      (list @racket[ival-log1p]     "tight")
-      (list @racket[ival-logb]      "tight")
-      (list @racket[ival-pow]       "refinement")
-      (list @racket[ival-sin]       "valid")
-      (list @racket[ival-cos]       "valid")
-      (list @racket[ival-tan]       "valid")
-      (list @racket[ival-asin]      "tight")
-      (list @racket[ival-acos]      "tight")
-      (list @racket[ival-atan]      "tight")
-      (list @racket[ival-atan2]     "valid")
-      (list @racket[ival-sinh]      "tight")
-      (list @racket[ival-cosh]      "tight")
-      (list @racket[ival-tanh]      "tight")
-      (list @racket[ival-asinh]     "tight")
-      (list @racket[ival-acosh]     "tight")
-      (list @racket[ival-atanh]     "tight")
-      (list @racket[ival-erf]       "tight")
-      (list @racket[ival-erfc]      "tight")
-      (list @racket[ival-tgamma]    "valid")
-      (list @racket[ival-lgamma]    "valid")
-      (list @racket[ival-fmod]      "valid")
-      (list @racket[ival-remainder] "valid")
-      (list @racket[ival-rint]      "tight")
-      (list @racket[ival-round]     "tight")
-      (list @racket[ival-ceil]      "tight")
-      (list @racket[ival-floor]     "tight")
-      (list @racket[ival-trunc]     "tight")
-      (list @racket[ival-fmin]      "tight")
-      (list @racket[ival-fmax]      "tight")
-      (list @racket[ival-copysign]  "tight")
-      (list @racket[ival-fdim]      "tight"))]
+@deftogether[(
+  @defproc[(ival-add [a ival?] [b ival?]) ival?]
+  @defproc[(ival-sub [a ival?] [b ival?]) ival?]
+  @defproc[(ival-neg [a ival?]) ival?]
+  @defproc[(ival-mul [a ival?] [b ival?]) ival?]
+  @defproc[(ival-div [a ival?] [b ival?]) ival?]
+  @defproc[(ival-fabs [a ival?]) ival?]
+  @defproc[(ival-sqrt [a ival?]) ival?]
+  @defproc[(ival-cbrt [a ival?]) ival?]
+  @defproc[(ival-hypot [a ival?] [b ival?]) ival?]
+  @defproc[(ival-exp [a ival?]) ival?]
+  @defproc[(ival-exp2 [a ival?]) ival?]
+  @defproc[(ival-exp2m1 [a ival?]) ival?]
+  @defproc[(ival-log [a ival?]) ival?]
+  @defproc[(ival-log2 [a ival?]) ival?]
+  @defproc[(ival-log10 [a ival?]) ival?]
+  @defproc[(ival-log1p [a ival?]) ival?]
+  @defproc[(ival-logb [a ival?]) ival?]
+  @defproc[(ival-asin [a ival?]) ival?]
+  @defproc[(ival-acos [a ival?]) ival?]
+  @defproc[(ival-atan [a ival?]) ival?]
+  @defproc[(ival-sinh [a ival?]) ival?]
+  @defproc[(ival-cosh [a ival?]) ival?]
+  @defproc[(ival-tanh [a ival?]) ival?]
+  @defproc[(ival-asinh [a ival?]) ival?]
+  @defproc[(ival-acosh [a ival?]) ival?]
+  @defproc[(ival-atanh [a ival?]) ival?]
+  @defproc[(ival-erf [a ival?]) ival?]
+  @defproc[(ival-erfc [a ival?]) ival?]
+  @defproc[(ival-rint [a ival?]) ival?]
+  @defproc[(ival-round [a ival?]) ival?]
+  @defproc[(ival-ceil [a ival?]) ival?]
+  @defproc[(ival-floor [a ival?]) ival?]
+  @defproc[(ival-trunc [a ival?]) ival?]
+  @defproc[(ival-fmin [a ival?] [b ival?]) ival?]
+  @defproc[(ival-fmax [a ival?] [b ival?]) ival?]
+  @defproc[(ival-copysign [a ival?] [b ival?]) ival?]
+  @defproc[(ival-fdim [a ival?] [b ival?]) ival?]
+)]{
+  These are all interval functions with arguments in the order
+  corresponding to the same-name @code{math.h} functions. The
+  precision of the output can be set with @racket[bf-precision].
+  All of these functions are weakly complete, returning the tightest
+  possible intervals for the strongest possible guarantees.
+}
+
+@deftogether[(
+  @defproc[(ival-fma [a ival?] [b ival?] [c ival?]) ival?]
+  @defproc[(ival-pow [a ival?] [b ival?]) ival?]
+  @defproc[(ival-sin [a ival?]) ival?]
+  @defproc[(ival-cos [a ival?]) ival?]
+  @defproc[(ival-tan [a ival?]) ival?]
+  @defproc[(ival-atan2 [a ival?] [b ival?]) ival?]
+)]{
+  These interval functions, like the previous set, are analogous to
+  the same-name @code{math.h} functions and set their precision with
+  @racket[bf-precision]. However, these functions are more complex and
+  do not guarantee weak completeness. We do, however, have high
+  confidence that they satisfy the refinement property.
+}
+
+@deftogether[(
+  @defproc[(ival-fmod [a ival?] [b ival?]) ival?]
+  @defproc[(ival-remainder [a ival?] [b ival?]) ival?]
+)]{
+  Like the others, these interval functions take arguments and return
+  values analogous to the same-name @code{math.h} functions and
+  produce output with @racket[bf-precision] precision. However,
+  these functions do not guarantee refinement in all cases due to
+  several subtle double-rounding cases.
+}
+
+@deftogether[(
+  @defproc[(ival-tgamma [a ival?]) ival?]
+  @defproc[(ival-lgamma [a ival?]) ival?]
+)]{
+  These two interval functions (which take arguments and return
+  values analogous to the same-name @code{math.h} functions and
+  produce output with @racket[bf-precision] precision) are extremely
+  slow, and we have only moderate confidence that these functions
+  satisfy soundness in all cases. We do not recommended using these
+  functions in typical use cases or at high precision.
+
+  @history[#:changed "1.7" @elem{Added @racket[ival-tgamma] and @racket[ival-lgamma]}]
+}
+
+@defproc[(ival-sort [lst (listof ival?)]
+                  [< (-> (or/c bigfloat? boolean?)
+                        (or/c bigfloat? boolean?)
+                        boolean?)])
+        (listof ival?)]{
+  Sorts a list of intervals using a comparator function.
+}
 
 @section{Interval Helper Functions}
 

--- a/scribblings/core.scrbl
+++ b/scribblings/core.scrbl
@@ -57,17 +57,6 @@ functions, which return different intervals at different
 
 @section{Interval Operations}
 
-Rival provides a large set of interval operations. All of these
-operations are sound, meaning that the output interval always contains
-all valid outputs from points in the input intervals.
-
-Most operations are also weakly complete, meaning that the endpoints
-of the output interval come from some point in the input intervals
-(rounded outwards). Not all operations are weakly complete, however.
-
-These operations have their output precision determined by
-@racket[bf-precision].
-
 @deftogether[(
   @defproc[(ival-add [a ival?] [b ival?]) ival?]
   @defproc[(ival-sub [a ival?] [b ival?]) ival?]
@@ -86,7 +75,7 @@ These operations have their output precision determined by
   @defproc[(ival-log2 [a ival?]) ival?]
   @defproc[(ival-log10 [a ival?]) ival?]
   @defproc[(ival-log1p [a ival?]) ival?]
-  @defproc[(ival-log1b [a ival?]) ival?]
+  @defproc[(ival-logb [a ival?]) ival?]
   @defproc[(ival-pow [a ival?] [b ival?]) ival?]
   @defproc[(ival-sin [a ival?]) ival?]
   @defproc[(ival-cos [a ival?]) ival?]
@@ -118,15 +107,8 @@ These operations have their output precision determined by
   @defproc[(ival-fdim [a ival?] [b ival?]) ival?]
 )]{
   These are all interval functions with arguments in the order
-  corresponding to the same-name @code{math.h} functions. Barring
-  bugs, all are sound. Most are weakly complete, though some more
-  complex functions aren't, including @racket[ival-pow],
-  @racket[ival-fma], @racket[ival-fmod], and @racket[ival-atan2]. Even
-  these fuctions still make a best-effort attempt to produce
-  relatively narrow intervals. For example, @racket[ival-fma] is
-  implemented via the formula @code{(fma a b c) = (+ (* a b) c)},
-  which that it accumulates multiple rounding errors. The result is
-  therefore not maximally tight, but typically still pretty close.
+  corresponding to the same-name @code{math.h} functions. The
+  precision of the output can be set with @racket[bf-precision].
 
   @history[#:changed "1.7" @elem{Added @racket[ival-tgamma] and @racket[ival-lgamma]}]
 }
@@ -138,6 +120,81 @@ These operations have their output precision determined by
         (listof ival?)]{
   Sorts a list of intervals using a comparator function.
 }
+
+Rival aims to ensure three properties of all helper functions:
+
+@itemlist[
+  @item{
+    @italic{Soundness} means output intervals contain any
+    output on inputs drawn from the input intervals.
+    IEEE-1788 refers to this as the output interval being @italic{valid}.
+  }
+
+  @item{
+    @italic{Refinement} means, moreover, that narrower input intervals
+    lead to narrower output intervals. Rival's movability flags make this
+    a somewhat more complicated property than typical.
+  }
+
+  @item{
+    @italic{Weak completeness} means, moreover, that Rival returns
+    the narrowest possible valid interval. IEEE-1788 refers
+    to this as the output interval being @italic{tight}.
+  }
+]
+
+Weak completeness (tightness) is the strongest possible property,
+while soundness (validity) is the weakest, with refinement somewhere
+in between. Rival's interval functions offer the following guarantees:
+
+@tabular[
+(list (list @racket[ival-add]       "tight")
+      (list @racket[ival-sub]       "tight")
+      (list @racket[ival-neg]       "tight")
+      (list @racket[ival-mul]       "tight")
+      (list @racket[ival-div]       "tight")
+      (list @racket[ival-fma]       "refinement")
+      (list @racket[ival-fabs]      "tight")
+      (list @racket[ival-sqrt]      "tight")
+      (list @racket[ival-cbrt]      "tight")
+      (list @racket[ival-hypot]     "tight")
+      (list @racket[ival-exp]       "tight")
+      (list @racket[ival-exp2]      "tight")
+      (list @racket[ival-exp2m1]    "tight")
+      (list @racket[ival-log]       "tight")
+      (list @racket[ival-log2]      "tight")
+      (list @racket[ival-log10]     "tight")
+      (list @racket[ival-log1p]     "tight")
+      (list @racket[ival-logb]      "tight")
+      (list @racket[ival-pow]       "refinement")
+      (list @racket[ival-sin]       "valid")
+      (list @racket[ival-cos]       "valid")
+      (list @racket[ival-tan]       "valid")
+      (list @racket[ival-asin]      "tight")
+      (list @racket[ival-acos]      "tight")
+      (list @racket[ival-atan]      "tight")
+      (list @racket[ival-atan2]     "valid")
+      (list @racket[ival-sinh]      "tight")
+      (list @racket[ival-cosh]      "tight")
+      (list @racket[ival-tanh]      "tight")
+      (list @racket[ival-asinh]     "tight")
+      (list @racket[ival-acosh]     "tight")
+      (list @racket[ival-atanh]     "tight")
+      (list @racket[ival-erf]       "tight")
+      (list @racket[ival-erfc]      "tight")
+      (list @racket[ival-tgamma]    "valid")
+      (list @racket[ival-lgamma]    "valid")
+      (list @racket[ival-fmod]      "valid")
+      (list @racket[ival-remainder] "valid")
+      (list @racket[ival-rint]      "tight")
+      (list @racket[ival-round]     "tight")
+      (list @racket[ival-ceil]      "tight")
+      (list @racket[ival-floor]     "tight")
+      (list @racket[ival-trunc]     "tight")
+      (list @racket[ival-fmin]      "tight")
+      (list @racket[ival-fmax]      "tight")
+      (list @racket[ival-copysign]  "tight")
+      (list @racket[ival-fdim]      "tight"))]
 
 @section{Interval Helper Functions}
 

--- a/test.rkt
+++ b/test.rkt
@@ -313,27 +313,27 @@
 
   (unless (set-member? non-refine-tests ival-fn)
     (with-check-info
-      (['intervals is] ['points xs] ['iy iy] ['y y] ['precs (list out-prec in-precs)])
-      (for ([k (in-naturals)]
-            [i is]
-            [x xs])
-        (define-values (ilo ihi) (ival-split i x))
-        (when (and ilo ihi)
-          (define iylo
-            (parameterize ([bf-precision out-prec])
-              (apply ival-fn (list-set is k ilo))))
-          (define iyhi
-            (parameterize ([bf-precision out-prec])
-              (apply ival-fn (list-set is k ihi))))
-          (with-check-info (['split-argument k] ['ilo ilo] ['ihi ihi] ['iylo iylo] ['iyhi iyhi])
-            (check-ival-equals? iy
-                                (parameterize ([bf-precision out-prec])
-                                  (ival-union iylo iyhi))))))
-      (when (or (ival-lo-fixed? iy) (ival-hi-fixed? iy))
-        (define iy*
-          (parameterize ([bf-precision 128])
-            (apply ival-fn is)))
-        (check ival-refines? iy iy*)))))
+     (['intervals is] ['points xs] ['iy iy] ['y y] ['precs (list out-prec in-precs)])
+     (for ([k (in-naturals)]
+           [i is]
+           [x xs])
+       (define-values (ilo ihi) (ival-split i x))
+       (when (and ilo ihi)
+         (define iylo
+           (parameterize ([bf-precision out-prec])
+             (apply ival-fn (list-set is k ilo))))
+         (define iyhi
+           (parameterize ([bf-precision out-prec])
+             (apply ival-fn (list-set is k ihi))))
+         (with-check-info (['split-argument k] ['ilo ilo] ['ihi ihi] ['iylo iylo] ['iyhi iyhi])
+                          (check-ival-equals? iy
+                                              (parameterize ([bf-precision out-prec])
+                                                (ival-union iylo iyhi))))))
+     (when (or (ival-lo-fixed? iy) (ival-hi-fixed? iy))
+       (define iy*
+         (parameterize ([bf-precision 128])
+           (apply ival-fn is)))
+       (check ival-refines? iy iy*)))))
 
 (define (run-tests)
   (check ival-contains? (ival-bool #f) #f)

--- a/test.rkt
+++ b/test.rkt
@@ -274,6 +274,9 @@
 (define num-tests 1000)
 (define num-witnesses 10)
 
+;; These fail refinement due to double-rounding sending us down the wrong branch
+(define non-refine-tests (list ival-fmod ival-remainder))
+;; These are super slow due to trying to find the minimum
 (define slow-tests (list ival-lgamma ival-tgamma))
 (define num-slow-tests 25)
 
@@ -308,28 +311,29 @@
     (with-check-info (['intervals is] ['points xs] ['precs (list out-prec in-precs)])
                      (check ival-contains? iy y)))
 
-  (with-check-info
-   (['intervals is] ['points xs] ['iy iy] ['y y] ['precs (list out-prec in-precs)])
-   (for ([k (in-naturals)]
-         [i is]
-         [x xs])
-     (define-values (ilo ihi) (ival-split i x))
-     (when (and ilo ihi)
-       (define iylo
-         (parameterize ([bf-precision out-prec])
-           (apply ival-fn (list-set is k ilo))))
-       (define iyhi
-         (parameterize ([bf-precision out-prec])
-           (apply ival-fn (list-set is k ihi))))
-       (with-check-info (['split-argument k] ['ilo ilo] ['ihi ihi] ['iylo iylo] ['iyhi iyhi])
-                        (check-ival-equals? iy
-                                            (parameterize ([bf-precision out-prec])
-                                              (ival-union iylo iyhi))))))
-   (when (or (ival-lo-fixed? iy) (ival-hi-fixed? iy))
-     (define iy*
-       (parameterize ([bf-precision 128])
-         (apply ival-fn is)))
-     (check ival-refines? iy iy*))))
+  (unless (set-member? non-refine-tests ival-fn)
+    (with-check-info
+      (['intervals is] ['points xs] ['iy iy] ['y y] ['precs (list out-prec in-precs)])
+      (for ([k (in-naturals)]
+            [i is]
+            [x xs])
+        (define-values (ilo ihi) (ival-split i x))
+        (when (and ilo ihi)
+          (define iylo
+            (parameterize ([bf-precision out-prec])
+              (apply ival-fn (list-set is k ilo))))
+          (define iyhi
+            (parameterize ([bf-precision out-prec])
+              (apply ival-fn (list-set is k ihi))))
+          (with-check-info (['split-argument k] ['ilo ilo] ['ihi ihi] ['iylo iylo] ['iyhi iyhi])
+            (check-ival-equals? iy
+                                (parameterize ([bf-precision out-prec])
+                                  (ival-union iylo iyhi))))))
+      (when (or (ival-lo-fixed? iy) (ival-hi-fixed? iy))
+        (define iy*
+          (parameterize ([bf-precision 128])
+            (apply ival-fn is)))
+        (check ival-refines? iy iy*)))))
 
 (define (run-tests)
   (check ival-contains? (ival-bool #f) #f)


### PR DESCRIPTION
Refinement is the property that, if `A ⊆ B`, then `f(A) ⊆ f(B)`. I thought all of our functions guaranteed this, but actually `ival-fmod` and `ival-remainder` don't; that's at the core of #111. This PR fixes #111 by explicitly turning off tests for refinement for these two functions.

Ideally we'd document our guarantees and implementation quality for each operator.