### PR TITLE
Cache rival machine max precision

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,9 @@ jobs:
         run: raco pkg install --name rival --no-cache --auto
       - name: "Install raco fmt"
         run: raco pkg install --auto fmt
+      - name: "Run tests"
+        run: raco test .
       - name: "Reformat all of the source code"
         run: raco fmt -i **/*.rkt
       - name: "Make sure files are correctly formatted with raco fmt"
         run: git diff --exit-code
-      - run: raco test .

--- a/eval/adjust.rkt
+++ b/eval/adjust.rkt
@@ -262,14 +262,14 @@
 ;   vprecs-max[i] = (+ max-prec vstart-precs[i]), where min-prec < (+ max-prec vstart-precs[i]) < max-prec
 ;   max-prec = (car (get-bounds parent))
 (define (precision-tuning machine-max-precision
-                           ivec
-                           vregs
-                           vprecs-max
-                           varc
-                           vstart-precs
-                           vrepeats
-                           vhint
-                           constants)
+                          ivec
+                          vregs
+                          vprecs-max
+                          varc
+                          vstart-precs
+                          vrepeats
+                          vhint
+                          constants)
   (define vprecs-min (make-vector (vector-length ivec) 0))
   (for ([instr (in-vector ivec (- (vector-length ivec) 1) -1 -1)]
         [repeat? (in-vector vrepeats (- (vector-length vrepeats) 1) -1 -1)]
@@ -282,7 +282,8 @@
     (define tail-registers (drop-self-pointer (cdr instr) n))
     (define srcs (append (map (lambda (x) (vector-ref vregs x)) tail-registers) constant))
 
-    (define parent-max-prec (vector-ref vprecs-max (- n varc))) ; upper precision bound given from parent
+    (define parent-max-prec
+      (vector-ref vprecs-max (- n varc))) ; upper precision bound given from parent
     (define min-prec (vector-ref vprecs-min (- n varc))) ; lower precision bound given from parent
 
     ; Final precision assignment based on the upper bound

--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -325,6 +325,7 @@
                  (make-vector (vector-length roots))
                  default-hint
                  constants-lookup
+                 (*rival-max-precision*)
                  0
                  0
                  0

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -34,6 +34,7 @@
                    output-distance
                    default-hint
                    constant-lookup
+                   max-precision
                    [iteration #:mutable]
                    [bumps #:mutable]
                    [profile-ptr #:mutable]


### PR DESCRIPTION
This PR saves the maximum precision in the `rival-machine` struct when compiling. Longer term, the plan is to use this to allocate registers correctly and thereby save memory usage.

https://chatgpt.com/codex/tasks/task_e_68d05789ffb483318c789305129dd890