### PR TITLE
Speed up making point-intervals with an `eq?` check

### DIFF
--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -74,13 +74,13 @@
                (execution instruction number precision time memory iter))
        (set-rival-machine-profile-ptr! machine 0))]))
 
-(define (ival-real x)
-  (ival x))
-
 ; Assumes that hint (if provided) is correct for the given pt
 (define (rival-apply machine pt [hint #f])
   ; Load arguments
-  (rival-machine-load machine (vector-map ival-real pt))
+  (define ival-pt
+    (for/vector #:length (vector-length pt) ([x (in-vector pt)])
+      (ival x)))
+  (rival-machine-load machine ival-pt)
   (let loop ([iter 0])
     (define-values (good? done? bad? stuck? fvec)
       (parameterize ([*sampling-iteration* iter])

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -126,6 +126,9 @@
 
 (define (mk-big-ival x y)
   (cond
+    [(eq? x y)
+     (define err? (and (bigfloat? x) (or (bfinfinite? x) (bfnan? x))))
+     (ival (endpoint x #t) (endpoint x #t) err? err?)]
     [(and (bigfloat? x) (bigfloat? y))
      (define fix? (bf=? x y))
      (define err? (or (bfnan? x) (bfnan? y) (and (bfinfinite? x) fix?)))


### PR DESCRIPTION
This PR does what it says on the tin: make `(ival x)` faster by handling point intervals explicitly in `mk-big-ival`.