### PR TITLE
Unify the allocation strategy for mutable and immutable bigfloats

### DIFF
--- a/eval/compile.rkt
+++ b/eval/compile.rkt
@@ -296,7 +296,7 @@
                  [n (in-naturals num-vars)])
       (fn->ival-fn node
                    (lambda ()
-                     (vector-set! registers n (new-ival))
+                     (vector-set! registers n (new-ival (*rival-max-precision*)))
                      n)
                    constants-lookup
                    (- n num-vars))))

--- a/eval/machine.rkt
+++ b/eval/machine.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 
+(require "../mpfr.rkt")
 (provide (struct-out discretization)
          (struct-out rival-machine)
          *rival-max-precision*
@@ -12,7 +13,6 @@
          *base-tuning-precision*
          *bumps-activated*)
 
-(define *rival-max-precision* (make-parameter 10000))
 (define *rival-min-precision* (make-parameter 20))
 (define *rival-max-iterations* (make-parameter 5))
 (define *rival-profile-executions* (make-parameter 1000))

--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -72,7 +72,8 @@
   (rival-machine-load machine (vector-map ival-real pt))
   (let loop ([iter 0])
     (define-values (good? done? bad? stuck? fvec)
-      (parameterize ([*sampling-iteration* iter])
+      (parameterize ([*sampling-iteration* iter]
+                     [*rival-max-precision* (rival-machine-max-precision machine)])
         (rival-machine-full machine (or hint (rival-machine-default-hint machine)))))
     (cond
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]

--- a/infra/run-baseline.rkt
+++ b/infra/run-baseline.rkt
@@ -23,6 +23,7 @@
                    registers
                    precisions
                    best-known-precisions
+                   max-precision
                    repeats
                    initial-repeats
                    default-hint
@@ -160,7 +161,7 @@
                  [n (in-naturals num-vars)])
       (fn->ival-fn node ; mappings are taken from Rival machine
                    (lambda ()
-                     (vector-set! registers n (new-ival))
+                     (vector-set! registers n (new-ival (*rival-max-precision*)))
                      n))))
 
   (define start-prec (+ (discretization-target (last discs)) 10))
@@ -181,6 +182,7 @@
                     registers
                     precisions
                     best-known-precisions
+                    (*rival-max-precision*)
                     repeats
                     initial-repeats
                     default-hint
@@ -199,6 +201,7 @@
 
 (define (baseline-apply machine pt [hint #f])
   (define discs (baseline-machine-discs machine))
+  (define max-precision (baseline-machine-max-precision machine))
   (define start-prec (+ (discretization-target (last discs)) 10))
   ; Load arguments
   (baseline-machine-load machine (vector-map ival-real pt))
@@ -212,7 +215,7 @@
       [bad? (raise (exn:rival:invalid "Invalid input" (current-continuation-marks) pt))]
       [done? fvec]
       [stuck? (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
-      [(> (* 2 prec) (*rival-max-precision*)) ; max precision is taken from eval/machine.rkt
+      [(> (* 2 prec) max-precision) ; max precision is taken from eval/machine.rkt
        (raise (exn:rival:unsamplable "Unsamplable input" (current-continuation-marks) pt))]
       [else (loop (* 2 prec) (+ iter 1))])))
 

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -3,6 +3,8 @@
 (require math/private/bigfloat/mpfr
          ffi/unsafe)
 
+(define *rival-max-precision* (make-parameter 10000))
+
 (provide -inf.bf
          -1.bf
          0.bf
@@ -13,7 +15,8 @@
          +inf.bf
          +nan.bf
          bf-return-exact?
-         rnd)
+         rnd
+         *rival-max-precision*)
 
 (define-syntax-rule (rnd mode op args ...)
   (parameterize ([bf-rounding-mode mode])
@@ -56,16 +59,18 @@
 (define mpfr-remainder!
   (get-mpfr-fun 'mpfr_remainder (_fun _mpfr-pointer _mpfr-pointer _mpfr-pointer _rnd_t -> _int)))
 
-(define mpfr-set-prec! (get-mpfr-fun 'mpfr_set_prec (_fun _mpfr-pointer _prec_t -> _void)))
-
-(define mpfr-init2! (get-mpfr-fun 'mpfr_init2 (_fun _mpfr-pointer _prec_t -> _void)))
+;(define mpfr-set-prec! (get-mpfr-fun 'mpfr_set_prec (_fun _mpfr-pointer _prec_t -> _void)))
 
 (define mpfr-set! (get-mpfr-fun 'mpfr_set (_fun _mpfr-pointer _mpfr-pointer _rnd_t -> _void)))
 
 (define (mpfr-new! prec)
-  (define bf (make-mpfr 0 0 0 #f))
-  (mpfr-init2! bf prec)
-  bf)
+  (unless (<= 2 prec (*rival-max-precision*))
+    (error 'mpfr-new! "Cannot create an MPFR value with precision ~a" prec))
+  (define x (parameterize ([bf-precision (*rival-max-precision*)]) (bf 0)))
+  (set-mpfr-prec! x prec)
+  x)
+
+(define mpfr-set-prec! set-mpfr-prec!)
 
 (define (bfremainder x mod)
   (define out (bf 0))

--- a/mpfr.rkt
+++ b/mpfr.rkt
@@ -63,13 +63,6 @@
 
 (define mpfr-set! (get-mpfr-fun 'mpfr_set (_fun _mpfr-pointer _mpfr-pointer _rnd_t -> _void)))
 
-(define (mpfr-new! prec)
-  (unless (<= 2 prec (*rival-max-precision*))
-    (error 'mpfr-new! "Cannot create an MPFR value with precision ~a" prec))
-  (define x (parameterize ([bf-precision (*rival-max-precision*)]) (bf 0)))
-  (set-mpfr-prec! x prec)
-  x)
-
 (define mpfr-set-prec! set-mpfr-prec!)
 
 (define (bfremainder x mod)
@@ -235,5 +228,4 @@
          mpfr-mul!
          mpfr-div!
          mpfr-set-prec!
-         mpfr-new!
          mpfr-set!)

--- a/ops/arith.rkt
+++ b/ops/arith.rkt
@@ -35,7 +35,7 @@
         (or (ival-err x) (ival-err y))))
 
 (define (ival-add x y)
-  (ival-add! (new-ival) x y))
+  (ival-add! (new-ival (bf-precision)) x y))
 
 (define (ival-sub! out x y)
   (ival (eplinear! (ival-lo-val out) mpfr-sub! (ival-lo x) (ival-hi y) 'down)
@@ -44,7 +44,7 @@
         (or (ival-err x) (ival-err y))))
 
 (define (ival-sub x y)
-  (ival-sub! (new-ival) x y))
+  (ival-sub! (new-ival (bf-precision)) x y))
 
 (define (epmul! out a-endpoint b-endpoint a-class b-class)
   (match-define (endpoint a a!) a-endpoint)
@@ -66,9 +66,10 @@
                 (and b! (bfinfinite? b) (not (= a-class 0))))))
 
 (define (ival-mult x y)
-  (ival-mult! (new-ival) x y))
+  (ival-mult! (new-ival (bf-precision)) x y))
 
-(define extra-mult-ival (new-ival))
+(define extra-mult-ival-prec (*rival-max-precision*))
+(define extra-mult-ival (new-ival extra-mult-ival-prec))
 
 (define (ival-mult! out x y)
   (match-define (ival xlo xhi xerr? xerr) x)
@@ -96,6 +97,9 @@
     ;; Here, the two branches of the union are meaningless on their own;
     ;; however, both branches compute possible lo/hi's to min/max together
     [(0 0)
+     (when (< extra-mult-ival-prec (*rival-max-precision*))
+       (set! extra-mult-ival-prec (*rival-max-precision*))
+       (set! extra-mult-ival (new-ival extra-mult-ival-prec)))
      (match-define (ival (endpoint lo lo!) (endpoint hi hi!) err? err)
        (ival-union (mkmult extra-mult-ival xhi ylo xlo ylo) (mkmult out xlo yhi xhi yhi)))
      (mpfr-set! (ival-lo-val out) lo 'down) ; should be exact
@@ -145,7 +149,7 @@
     [(0 -1) (mkdiv xhi yhi xlo yhi)]))
 
 (define (ival-div x y)
-  (ival-div! (new-ival) x y))
+  (ival-div! (new-ival (bf-precision)) x y))
 
 (define (ival-fma a b c)
   (ival-add (ival-mult a b) c))

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -118,10 +118,10 @@
 (define (ival-hi-fixed? ival)
   (endpoint-immovable? (ival-hi ival)))
 
-(define (new-ival)
+(define (new-ival precision)
   ; Warning, leaks memory unless `mpfr-clear!` called eventually
-  (define bf1 (mpfr-new! (bf-precision)))
-  (define bf2 (mpfr-new! (bf-precision)))
+  (define bf1 (parameterize ([bf-precision precision]) (bf 0)))
+  (define bf2 (parameterize ([bf-precision precision]) (bf 0)))
   (ival (endpoint bf1 #f) (endpoint bf2 #f) #f #f))
 
 (define (mk-big-ival x y)

--- a/ops/core.rkt
+++ b/ops/core.rkt
@@ -119,10 +119,8 @@
   (endpoint-immovable? (ival-hi ival)))
 
 (define (new-ival precision)
-  ; Warning, leaks memory unless `mpfr-clear!` called eventually
-  (define bf1 (parameterize ([bf-precision precision]) (bf 0)))
-  (define bf2 (parameterize ([bf-precision precision]) (bf 0)))
-  (ival (endpoint bf1 #f) (endpoint bf2 #f) #f #f))
+  (parameterize ([bf-precision precision])
+    (ival (endpoint (bf 1) #f) (endpoint (bf 2) #f) #f #f)))
 
 (define (mk-big-ival x y)
   (cond

--- a/time.rkt
+++ b/time.rkt
@@ -58,7 +58,9 @@
 
   ; Rival machine
   (define start-compile (current-inexact-milliseconds))
-  (define rival-machine (rival-compile exprs vars discs))
+  (define rival-machine
+    (parameterize ([*rival-max-precision* 32256])
+      (rival-compile exprs vars discs)))
   (define compile-time (- (current-inexact-milliseconds) start-compile))
 
   ; Baseline and Sollya machines

--- a/time.rkt
+++ b/time.rkt
@@ -64,7 +64,9 @@
   (define compile-time (- (current-inexact-milliseconds) start-compile))
 
   ; Baseline and Sollya machines
-  (define baseline-machine (baseline-compile exprs vars discs))
+  (define baseline-machine
+    (parameterize ([*rival-max-precision* 32256])
+      (baseline-compile exprs vars discs)))
 
   (define sollya-machine
     (match (or (equal? (cdr exprs) `((* (fmod (exp x) (sqrt (cos x))) (exp (neg x))))) ; id 65


### PR DESCRIPTION
This PR unifies mutable and immutable bigfloats, as in, they are allocated in the same way. Basically, `new-mpfr` allocates a standard "immutable" bigfloat of `*rival-max-precision*` bits. Then, instead of using `mpfr-set-prec!` you use `set-mpfr-prec!` to directly modify the precision field of the `mpfr_t`; since we "promise" that we only set this to precisions below the max precision this is safe.

I'd like to be more rigorous about using the saved machine precision vs `*rival-machine-precision*` and maybe have some more tests but seems OK as a start.