### PR TITLE
If stuck, return proper boolean intervals

### DIFF
--- a/eval/main.rkt
+++ b/eval/main.rkt
@@ -104,7 +104,9 @@
       (rival-machine-full machine (or hint (rival-machine-default-hint machine)))))
   (define-values (hint* hint*-converged?)
     (make-hint machine (or hint (rival-machine-default-hint machine))))
-  (list (ival (or bad? stuck?) (not good?)) hint* hint*-converged?))
+  ;; `stuck?` should be terminal for sampling, same as invalid.
+  ;; Keep the boolean interval valid by setting the upper bit as well.
+  (list (ival (or bad? stuck?) (or (not good?) stuck?)) hint* hint*-converged?))
 
 (define (rival-analyze machine rect)
   (car (rival-analyze-with-hints machine rect)))

--- a/infra/run-baseline.rkt
+++ b/infra/run-baseline.rkt
@@ -103,7 +103,7 @@
     (baseline-machine-full machine (or hint (rival-machine-default-hint machine))))
   (define-values (hint* hint*-converged?)
     (make-hint machine (or hint (rival-machine-default-hint machine))))
-  (list (ival (or bad? stuck?) (not good?)) hint* hint*-converged?))
+  (list (ival (or bad? stuck?) (or (not good?) stuck?)) hint* hint*-converged?))
 
 (define (baseline-machine-adjust machine)
   (let ([start-time (current-inexact-milliseconds)]


### PR DESCRIPTION
In `rival-analyze-with-hints`, if the interval is stuck but does not raise error flags, like in `(copysign 1 0)`, we were returning the invalid boolean interval `[#t, #f]`. This PR fixes it to return `[#t, #t]`. Luckily this never caused problems for Herbie since it uses the low endpoint anyway.